### PR TITLE
fix: stabilize and harden the blog release

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           for attempt in {1..60}; do
-            deployed_sha="$(curl --fail --silent --show-error https://www.sena-v.com/version || true)"
+            deployed_sha="$(curl --location --fail --silent --show-error https://sena-v.com/version || true)"
             if [ "$deployed_sha" = "$GITHUB_SHA" ]; then
               exit 0
             fi
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run production smoke test
         env:
-          PLAYWRIGHT_BASE_URL: https://www.sena-v.com/
+          PLAYWRIGHT_BASE_URL: https://sena-v.com/
         run: npm run e2e:playwright
 
       - name: Upload Playwright diagnostics

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 - Maintenance controls: CI, Renovate, security headers, dependency audits, E2E tests, and link validation
 - Responsive, keyboard-friendly design built primarily with Server Components and plain CSS
 
-The design and migration decisions are described in the public [2026 blog reboot article](https://sena-v.com/articles/blog-reboot-2026).
+The current design and migration decisions are recorded in the
+[implementation specification](docs/design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md).
+The 2026 reboot article remains a draft until its text has been reviewed separately.
 
 ## Stack
 
@@ -66,6 +68,7 @@ coverImage: "posts-image/example.png"
 publishedAt: "2026-08-02"
 updatedAt: "2026-08-10" # only after a meaningful content update
 featured: false
+draft: false # optional; must be a YAML boolean
 ---
 ```
 
@@ -83,6 +86,7 @@ tags: ["TypeScript"]
 externalUrl: "https://example.com/article"
 platform: "Example"
 featured: false
+draft: false # optional; must be a YAML boolean
 ---
 ```
 
@@ -99,6 +103,6 @@ Do not change an old `publishedAt` to make the archive look active. Add `updated
 
 ## Deployment
 
-Vercel builds the `main` branch. Creating a branch or pull request is safe; merging to `main` is a production release action and should happen only after CI and a visual review pass.
+Vercel builds the `main` branch. Creating a branch or pull request is safe; merging to `main` is a production release action and should happen only after CI and a visual review pass. The canonical production origin is `https://sena-v.com`; configure it as Vercel's primary domain and redirect `www.sena-v.com` to the apex host.
 
 Environment variables are documented in `.env.example`. Secrets and real analytics IDs must not be committed.

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { siteUrl } from "@/utils/constants"
 
 type ArticlePageProps = { params: Promise<{ slug: string }> }
 
+export const revalidate = 43200
+
 export const generateStaticParams = () => getLocalWritingsOnly().map(({ slug }) => ({ slug }))
 
 export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
@@ -55,7 +57,10 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }} />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+      />
       <ArticleExperience writing={writing as typeof writing & { content: string }} />
     </>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -693,23 +693,23 @@ img {
 .bootstrap-reader-header {
   height: 7.4%;
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  place-items: center;
-  padding-inline: 7%;
+  grid-template-columns: 44px 1fr 54px;
+  align-items: center;
+  padding-inline: 2.8%;
   border-bottom: 1px solid #292a31;
 }
 
 .bootstrap-reader-header i {
-  width: 18px;
-  height: 1px;
-  justify-self: start;
+  width: 17px;
+  height: 1.25px;
+  justify-self: center;
   background: #a7aab2;
-  box-shadow: 0 5px 0 #a7aab2, 0 -5px 0 #a7aab2;
+  box-shadow: 0 4.25px 0 #a7aab2, 0 -4.25px 0 #a7aab2;
 }
 
 .bootstrap-reader-header i:last-child {
-  width: 40px;
-  height: 22px;
+  width: 44px;
+  height: 24px;
   justify-self: end;
   background: #111218;
   border: 1px solid #3a3b43;
@@ -718,6 +718,7 @@ img {
 }
 
 .bootstrap-reader-header b {
+  justify-self: center;
   color: inherit;
   font-size: clamp(16.8px, 3.234cqw, 17.85px);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,9 @@
-import { redirect } from "next/navigation"
-
 import { ArticleExperience } from "@/components/ArticleExperience"
 import { getLocalWritingsOnly } from "@/lib/content"
 
-type HomeProps = {
-  searchParams: Promise<Record<string, string | string[] | undefined>>
-}
+export const revalidate = 43200
 
-export default async function Home({ searchParams }: HomeProps) {
-  const legacySlugValue = (await searchParams).slug
-  const legacySlug = Array.isArray(legacySlugValue) ? legacySlugValue[0] : legacySlugValue
-  if (legacySlug) redirect(`/articles/${encodeURIComponent(legacySlug)}`)
-
+export default async function Home() {
   const latest = getLocalWritingsOnly()[0]
   if (!latest?.content) throw new Error("At least one local article is required")
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -34,7 +34,7 @@ export default function PrivacyPage() {
         </p>
         <p>
           外部サイトへのリンクがクリックされたことは、Google Analyticsの拡張計測機能によって記録される場合があります。
-          ブログ内で入力された検索語は収集せず、メールアドレスと検索パラメータを送らないためのredactionを設定します。
+          page viewはqueryを除いたpathnameだけを送信し、ブログ内で入力された検索語は収集しません。加えて、メールアドレスと検索パラメータを送らないためのredactionを設定します。
           計測は本番サイトだけで行い、localhostとVercelのPreview Deploymentでは行いません。
         </p>
         <h2>Googleによるデータの扱いと無効化</h2>

--- a/docs/blog-improvement-roadmap.md
+++ b/docs/blog-improvement-roadmap.md
@@ -1,8 +1,8 @@
 # ブログ改善ロードマップ
 
-最終更新: 2026-08-03
+最終更新: 2026-08-04
 
-状態: GA4を計測基盤として採用。第5回の構造比較とrefinementを経て、中央端末を縦横回転する[1st最終デザイン・機能仕様](./design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md)を確定。次は実DOMのprototypeから段階実装する。
+状態: GA4を計測基盤として採用。第5回の構造比較とrefinementを経て確定した[1st最終デザイン・機能仕様](./design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md)を実装し、現在は公開前の安定性・Privacy・運用設定を検証している。
 
 ## この文書の目的
 
@@ -21,7 +21,7 @@
 - ローカルのCI、ビルド、主要画面のE2Eは通過済み。
 - このブランチはまだ `main` へマージも、本番公開もしていない。
 - 既存のGA4実装で見つけた初回PVの重複と環境の切り分けは、ローカルで修正済み。本番には未公開。
-- 人気順とデザインの本改修は未実装。
+- 人気順、responsive reader、遅延WebGL外装、縦横切替を実装済み。
 - GA4の本番設定確認は後から再開できる状態。現在はデザイン選定を先行する。
 - 第1回の5案、第2回の10案、第3回の20案、第4回の20案に加え、記事カバーとWebGL記事ビューアを検討する第5回を [`docs/design-research/`](./design-research/README.md) に保存した。現在は[1st最終デザイン・機能仕様](./design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md)を実装判断の基準にする。
 
@@ -114,7 +114,7 @@
 - 保守しやすく、表示性能を守れるか
 - テンプレート的、SaaS的、AI生成的に見えないか
 
-第5回では、画像を独立した観察記録ではなく記事カバーとして扱う。カバー指定時は本人素材、未指定時は管理された汎用カバーへフォールバックする。比較の結果、同一比率の中央端末、縦横回転、実DOMの記事reader、右側の小型回転操作、dark mode、scroll可能な記事索引を1st finalとして選んだ。詳細は[1st最終デザイン・機能仕様](./design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md)を参照する。次は実記事入りのlocalhost prototypeで、実DOMと索引を先に作り、WebGL外装、回転、GA4人気順を段階的に統合する。サイト共通ナビゲーションには年表を使わないが、年・月単位のarchiveはportrait左側へ残す。
+第5回では、画像を独立した観察記録ではなく記事カバーとして扱う。カバー指定時は本人素材、未指定時は管理された汎用カバーへフォールバックする。比較の結果、同一比率の中央端末、縦横回転、実DOMの記事reader、右側の小型回転操作、dark mode、scroll可能な記事索引を1st finalとして選び、実記事を使うproduction UIへ統合した。詳細は[1st最終デザイン・機能仕様](./design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md)と[実装検証記録](./design-research/round-5-article-cover-engineering/IMPLEMENTATION_VERIFICATION.md)を参照する。
 
 ### 5. 人気順をUIへ加える
 
@@ -184,7 +184,7 @@
 実装前の確認事項:
 
 - 既存GA4プロパティの所有者、Measurement ID、データ期間を確認する。
-- 拡張計測の「ブラウザの履歴イベントに基づくページの変更」が有効であることを確認する。
+- 拡張計測の「ブラウザの履歴イベントに基づくページの変更」が無効であることを確認する。
 - RealtimeまたはDebugViewで、初回表示と画面遷移がそれぞれ1回だけ計測されることを確認する。
 - Google Signalsと広告パーソナライズを利用しない設定を確認する。
 - メールアドレスのredactionと、ブログ内検索パラメータ `query` のredactionを有効にする。
@@ -193,7 +193,7 @@
 - Google CloudでData APIを有効化し、読み取り専用サービスアカウントを用意する。
 - Privacyページの内容と実際の設定が一致していることを確認する。
 
-既存実装では、初期化時の `config` とReactのEffect内の `config` が重なり、初回PVを二重送信する可能性があった。GoogleがSPA向けに推奨するブラウザ履歴ベースの自動計測へ一本化し、`config` は一度だけ呼ぶ。外部リンククリックは拡張計測に任せ、同じイベントを独自コードから重複送信しない。
+既存実装では、初期化時の `config` とReactのEffect内の `config` が重なり、初回PVを二重送信する可能性があった。現在は `send_page_view: false` で初期化し、App Routerが確定したpathnameだけを手動送信する。GA4管理画面側でも履歴変更page viewを無効にし、検索queryの送信と二重計測を防ぐ。外部リンククリックは拡張計測に任せる。
 
 参考:
 

--- a/docs/design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md
+++ b/docs/design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md
@@ -274,7 +274,9 @@ native scrollの挙動を維持し、wheel、trackpad、touch drag、scrollbar d
 ## 15. Performance
 
 - mobileではWebGL bundleを読み込まない構成を優先する。
-- desktopでもcanvasをlazy-loadし、記事本文とnavigationの初期表示を止めない。
+- desktopではDOM shellを同期的に読み込み、canvasだけをlazy-loadして記事本文とnavigationの初期表示を止めない。
+- server bootstrapとhydration後の端末外枠・header操作は同じgeometry tokenを使い、主要要素の座標差を`1px`未満にする。
+- hydration待ちを隠すための全面overlayは使わない。必要な遷移は端末内contentだけの短いcrossfadeに限定する。
 - idle中の連続60fps renderingを行わない。
 - 端末素材と比較画像は適切に圧縮し、実ページの記事画像はresponsive sourceを使う。
 - fontは必要weightだけをself-hostまたは適切にsubsetする。
@@ -305,6 +307,7 @@ native scrollの挙動を維持し、wheel、trackpad、touch drag、scrollbar d
 - [x] 実スマートフォンでは端末外装を表示せず、同じ記事readerを直接使える。
 - [x] PV実数とGA認証情報がclientへ露出しない。
 - [x] WebGL / GA4障害時にも記事閲覧と新着順が動く。
+- [x] desktopのhard reloadを繰り返しても端末外枠とtheme toggleが移動しない。
 - [x] Playwrightの主要viewport screenshot、keyboard操作、reduced motion、theme維持、fallbackのtestが通る。
 
 ## 18. 実装順

--- a/docs/design-research/round-5-article-cover-engineering/IMPLEMENTATION_VERIFICATION.md
+++ b/docs/design-research/round-5-article-cover-engineering/IMPLEMENTATION_VERIFICATION.md
@@ -1,8 +1,8 @@
 # Article cover implementation verification
 
-検証日: 2026-08-03
-対象branch: `feature/blog-reboot-2026`
-対象URL: `http://127.0.0.1:3000/` (`next build` + `next start`)
+検証日: 2026-08-04
+対象branch: `feature/blog-reboot-critical-fixes`
+対象URL: localhost (`next build` + `next start`)
 
 ## 仕様チェック
 
@@ -32,6 +32,7 @@
 - Aboutは「書いていること」と外部・記事一覧linkへ絞り、説明的な方針sectionを置かない。global headerはwordmarkとは別に`ホーム`を明示し、390px幅でも3リンクを横overflowさせない。
 - 外側左railは主見出しをeyebrowの1.6倍以上にし、`SENA-V.COM / READING DESK`へ18pxのpink ruleを付ける。主題と文脈labelを同じ強さにせず、意図的なhierarchyとして見せる。
 - desktop判定はclient navigation後もmatch結果を共有し、関連記事・人気記事・Archiveの内部link遷移でSP用readerを一度描画してからdesktopへ戻すflashを発生させない。遷移中のDOM mutationをE2Eで監視し、SP用DOM 0件とtheme維持を検証する。
+- hard reload時はDOM shellを同期読込し、server bootstrapとhydration後のtheme toggleを同じ寸法・座標に保つ。5回のreloadで端末外枠とtoggleの差が`1px`未満であることをE2Eで検証する。
 - hard reloadでは初期HTML内のmobile readerをdesktopへ一瞬表示しない。headの早期`js` markerとCSS media queryで同寸法の軽量bootstrap shellを選び、client chunkを遮断した状態でも端末・左右rail・記事見出しを安定表示する。JavaScript無効時は元のsemanticなresponsive readerを残し、mobile hydration後はbootstrap DOMを除去する。
 - リライト前の記事はfrontmatterの`draft`で管理し、一覧・トップ・関連記事・人気記事・Archive・RSS・sitemap・静的生成URLから同じcontent層で除外する。source fileは保持し、公開時にfrontmatterを戻せるようにする。
 - WebGLはdesktopのhover/focus/回転操作まで遅延し、CSS shellと記事DOMを先に表示する。
@@ -99,7 +100,7 @@ WebGLはhover後にcanvas 1件・readyとなり、pointer位置に応じてtilt�
 
 - CSP、HSTS、`X-Content-Type-Options`、`Referrer-Policy`、`Permissions-Policy`、COOP/CORP、frame拒否headerをproduction responseで検証した。
 - 外部記事frontmatterのURLはabsolute HTTP(S)だけを受理し、外部linkは `noopener noreferrer` と新規tab表記を持つ。
-- GA4とSpeed InsightsはVercel production以外では自動読込しない。
+- GA4とSpeed InsightsはVercel production以外では自動読込しない。GA4 page viewはqueryを除いたcanonical pathnameだけを手動送信し、管理画面の履歴変更page viewを無効にする。
 - GA4 service account secretは環境変数のみで扱い、client payloadはslugとfallback/GA4 sourceだけを受け取る。
 - credential形式のsecret scanでは `.env.example` の説明用placeholder以外を検出していない。
 - Markdown内のHTMLを直接実行せず、画像pathも既知のlocal assetだけを最適化対象にする。

--- a/docs/ga4-operations.md
+++ b/docs/ga4-operations.md
@@ -1,6 +1,6 @@
 # GA4運用・検証メモ
 
-最終更新: 2026-08-02
+最終更新: 2026-08-04
 
 この文書は、sena-v.comのGoogle Analytics 4計測を本番で有効にし、後からData APIで人気順を作るための作業記録である。Google Analyticsの管理画面やGoogle Cloudを変更する前に、対象アカウントとプロパティを確認する。
 
@@ -10,12 +10,13 @@
 - Vercelでは `VERCEL_ENV=production` のときだけGA4を読み込む。
 - Previewとlocalhostでは読み込まない。ローカルで検証するときだけ `GA4_ENABLED=true` を明示する。
 - 緊急停止時はProductionでも `GA4_ENABLED=false` にする。
-- `gtag('config')` は初期化時に一度だけ呼ぶ。
-- SPAの画面遷移はGA4拡張計測のブラウザ履歴イベントに任せる。
-- 独自のpage viewや外部リンククリックを重ねて送らない。
+- `gtag('config')` は `send_page_view: false` で初期化時に一度だけ呼ぶ。
+- page viewはApp Routerのpathname変更時に手動で一度だけ送る。`page_location`と`page_path`へqueryとfragmentを含めない。
+- GA4拡張計測の「ブラウザの履歴イベントに基づくページの変更」は無効にし、手動page viewと重複させない。
+- 外部リンククリックは拡張計測に任せ、独自eventを重ねて送らない。
 - Google Signalsと広告パーソナライズ用シグナルはコード側でも無効にする。
 
-Googleは、SPAではブラウザ履歴の変化による自動計測を推奨している。手動page viewと自動計測を併用すると重複するため、どちらか一つに揃える。
+手動page viewと自動履歴計測を併用すると重複する。検索条件をGET parameterで保持しながら検索文字列を送信しないため、このブログではpathnameだけを使う手動page viewへ統一する。
 
 - [Measure single-page applications](https://developers.google.com/analytics/devguides/collection/ga4/single-page-applications)
 - [Measure pageviews](https://developers.google.com/analytics/devguides/collection/ga4/views)
@@ -34,7 +35,7 @@ Googleは、SPAではブラウザ履歴の変化による自動計測を推奨�
 ### 2. Data stream
 
 - [ ] 拡張計測を有効にする。
-- [ ] Page viewsの詳細設定で「Page changes based on browser history events」を有効にする。
+- [ ] Page viewsの詳細設定で「Page changes based on browser history events」を無効にする。
 - [ ] 外部リンククリックを有効にする。
 - [ ] 独自コードやGoogle Tag Managerから同じpage viewを送っていないことを確認する。
 - [ ] Site searchは無効にし、ブログ内検索語を収集しない。
@@ -71,6 +72,7 @@ Googleは、SPAではブラウザ履歴の変化による自動計測を推奨�
 - [ ] 各画面で `page_view` が一度だけ記録される。
 - [ ] `/articles/{slug}` が正しいpage pathとして記録される。
 - [ ] Writingsで検索しても検索語がイベントやpage locationに残らない。
+- [ ] 初回表示とApp Router遷移で、各pathnameの `page_view` が一度だけ送信される。
 - [ ] 外部リンクは `click` と `outbound=true` で確認できる。
 - [ ] localhostの操作は記録されない。
 - [ ] Vercel Previewの操作は記録されない。

--- a/docs/portfolio-release-checklist.md
+++ b/docs/portfolio-release-checklist.md
@@ -31,6 +31,8 @@ Use this checklist one to two weeks before submitting sena-v.com for a job appli
 
 ## Release and application
 
+- [ ] In Vercel Domains, set `sena-v.com` as the Primary Domain and confirm `www.sena-v.com` redirects to the apex host.
+- [ ] In GA4 Enhanced Measurement, disable page views based on browser history and confirm manual pathname-only page views are not duplicated.
 - [ ] Review the final diff and CI results before merging to `main`.
 - [ ] Confirm the production deployment and its smoke test.
 - [ ] Open the site in a private browser session to catch authentication or cache mistakes.

--- a/e2e/playwright/site.spec.ts
+++ b/e2e/playwright/site.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test"
 
-test("desktopの初期HTMLはmobile readerを描画せず安定したshellを表示する", async ({ page }) => {
+test("desktopの初期HTMLとhydration後でshellとtheme toggleの位置が変わらない", async ({ page }) => {
   await page.setViewportSize({ width: 1619, height: 886 })
   await page.route("**/_next/static/chunks/**", (route) => (
     route.request().resourceType() === "script" ? route.abort() : route.continue()
@@ -12,16 +12,51 @@ test("desktopの初期HTMLはmobile readerを描画せず安定したshellを表
   await expect(page.locator(".desktop-reader-bootstrap")).toBeVisible()
   const bootstrapLayout = await page.evaluate(() => {
     const device = document.querySelector(".desktop-reader-bootstrap .device-shell")!.getBoundingClientRect()
+    const theme = document.querySelector(".bootstrap-reader-header i:last-child")!.getBoundingClientRect()
+    const menu = document.querySelector(".bootstrap-reader-header i:first-child")!.getBoundingClientRect()
+    const brand = document.querySelector(".bootstrap-reader-header b")!.getBoundingClientRect()
     return {
-      deviceWidth: device.width,
+      device: { x: device.x, y: device.y, width: device.width, height: device.height },
+      theme: { x: theme.x, y: theme.y, width: theme.width, height: theme.height },
+      menu: { x: menu.x, y: menu.y, width: menu.width, height: menu.height },
+      brand: { x: brand.x, y: brand.y, width: brand.width, height: brand.height },
       visibleRatio: (Math.min(device.bottom, innerHeight) - device.top) / device.height,
       overflowX: document.documentElement.scrollWidth - innerWidth,
     }
   })
-  expect(bootstrapLayout.deviceWidth).toBeGreaterThanOrEqual(600)
+  expect(bootstrapLayout.device.width).toBeGreaterThanOrEqual(600)
   expect(bootstrapLayout.visibleRatio).toBeGreaterThan(0.63)
   expect(bootstrapLayout.visibleRatio).toBeLessThan(0.65)
   expect(bootstrapLayout.overflowX).toBe(0)
+
+  await page.unroute("**/_next/static/chunks/**")
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await page.reload({ waitUntil: "domcontentloaded" })
+    await expect(page.locator(".theme-toggle")).toBeVisible()
+    const hydratedLayout = await page.evaluate(() => {
+      const device = document.querySelector(".device-shell")!.getBoundingClientRect()
+      const theme = document.querySelector(".theme-toggle")!.getBoundingClientRect()
+      const menu = document.querySelector(".reader-menu-button span:nth-child(2)")!.getBoundingClientRect()
+      const brand = document.querySelector(".reader-brand")!.getBoundingClientRect()
+      return {
+        device: { x: device.x, y: device.y, width: device.width, height: device.height },
+        theme: { x: theme.x, y: theme.y, width: theme.width, height: theme.height },
+        menu: { x: menu.x, y: menu.y, width: menu.width, height: menu.height },
+        brand: { x: brand.x, y: brand.y, width: brand.width, height: brand.height },
+      }
+    })
+    for (const key of ["x", "y", "width", "height"] as const) {
+      expect(Math.abs(hydratedLayout.device[key] - bootstrapLayout.device[key])).toBeLessThan(1)
+      expect(Math.abs(hydratedLayout.theme[key] - bootstrapLayout.theme[key])).toBeLessThan(1)
+    }
+    for (const element of ["menu", "brand"] as const) {
+      for (const axis of ["x", "y"] as const) {
+        const hydratedCenter = hydratedLayout[element][axis] + hydratedLayout[element][axis === "x" ? "width" : "height"] / 2
+        const bootstrapCenter = bootstrapLayout[element][axis] + bootstrapLayout[element][axis === "x" ? "width" : "height"] / 2
+        expect(Math.abs(hydratedCenter - bootstrapCenter)).toBeLessThan(1)
+      }
+    }
+  }
 })
 
 test("トップページが実記事を中心にしたdesktop readerを表示する", async ({ page }) => {
@@ -644,7 +679,7 @@ test("hamburger drawerはEscapeで閉じ、focusを戻す", async ({ page }) => 
       containedRight: drawer.right <= screen.right,
       containedBottom: drawer.bottom <= screen.bottom,
       sheetWidth: sheet.width,
-      sheetContained: sheet.left >= screen.left && sheet.right <= screen.right,
+      sheetOverflow: Math.max(screen.left - sheet.left, sheet.right - screen.right, 0),
       deviceTop: document.querySelector(".device-shell")!.getBoundingClientRect().top,
       deviceLeft: document.querySelector(".device-shell")!.getBoundingClientRect().left,
       tiltX: (document.querySelector(".device-shell") as HTMLElement).style.getPropertyValue("--device-tilt-x"),
@@ -662,7 +697,7 @@ test("hamburger drawerはEscapeで閉じ、focusを戻す", async ({ page }) => 
   expect(portraitDrawerPlacement.containedRight).toBe(true)
   expect(portraitDrawerPlacement.containedBottom).toBe(true)
   expect(portraitDrawerPlacement.sheetWidth).toBeGreaterThanOrEqual(350)
-  expect(portraitDrawerPlacement.sheetContained).toBe(true)
+  expect(portraitDrawerPlacement.sheetOverflow).toBeLessThan(1)
   expect(Math.abs(portraitDrawerPlacement.deviceTop - positionBeforePortraitDrawer.top)).toBeLessThan(0.5)
   expect(Math.abs(portraitDrawerPlacement.deviceLeft - positionBeforePortraitDrawer.left)).toBeLessThan(0.5)
   expect(Math.abs(Number.parseFloat(portraitDrawerPlacement.tiltX) - Number.parseFloat(positionBeforePortraitDrawer.tiltX)))
@@ -810,6 +845,9 @@ test("旧slug URLを新しい記事URLへ転送する", async ({ page }) => {
   await page.goto("/?slug=next-14-app-router")
   await expect(page).toHaveURL(/\/articles\/next-14-app-router$/)
   await expect(page.locator(".reader-article-header h1")).toContainText("Next14")
+
+  await page.goto("/?slug=..%2Fadmin")
+  await expect(page).toHaveURL(/\/?slug=\.\.%2Fadmin$/)
 
   await page.goto("/projects/blog-reboot")
   await expect(page).toHaveURL(/\/writings$/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.2.12",
         "eslint-config-prettier": "^10.1.8",
+        "picomatch": "^4.0.4",
         "prettier": "^3.4.2",
         "typescript": "^5"
       },
@@ -1271,7 +1272,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
       "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.62.1"
@@ -1423,7 +1424,6 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2187,7 +2187,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3307,7 +3306,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -4964,6 +4962,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5329,13 +5340,13 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5345,7 +5356,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.62.1"
@@ -5364,7 +5375,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
       "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -6240,19 +6251,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.12",
     "eslint-config-prettier": "^10.1.8",
+    "picomatch": "^4.0.4",
     "prettier": "^3.4.2",
     "typescript": "^5"
   },

--- a/posts/2023-01-17/index.md
+++ b/posts/2023-01-17/index.md
@@ -2,7 +2,6 @@
 title: "Wowza API v1.6->v1.9で認証方法を変更する"
 tags: ["node", "wowza"]
 slug: wowza-authorization-to-jwt
-coverImage: ""
 ---
 
 配信関連のタスクとして、wowzaのAPIアップデートを実施した際に記事がなかったため記録。
@@ -62,5 +61,4 @@ Invalid_Tokenでエラーになるためpostされる前のheaderが正確に生
 
 Lifecycle scheduleを見るとマイナーアップデートについては半年程となるため、  
 v1.9の2024年9月には再度対応が必要になるかもしれないので注視したいと思います。
-
 

--- a/posts/2023-01-26/index.md
+++ b/posts/2023-01-26/index.md
@@ -2,7 +2,6 @@
 title: "npmモジュールの更新チェックを自動化する"
 tags: ["TypeScript", "node", "npm"]
 slug: npm-module-auto-update-check
-coverImage: ""
 ---
 開発を実施している中でnpmを使用していると、依存しているモジュールの更新が発生した場合  
 多くのプロジェクトでははGitHub上でdependabotAlertが出てから対応することになります。  

--- a/posts/2023-02-21/index.md
+++ b/posts/2023-02-21/index.md
@@ -2,7 +2,6 @@
 title: "macOS Ventureアップデート後gitでエラーが出る"
 tags: ["macbook","環境構築"]
 slug: macbook-update-git-error
-coverImage:
 ---
 
 macのOSアップデート時には結構発生するっぽい

--- a/posts/2023-03-01/index.md
+++ b/posts/2023-03-01/index.md
@@ -2,7 +2,6 @@
 title: "開発時によく使うコマンド忘備録"
 tags: ["node","npm"]
 slug: command-daily-use
-coverImage:
 ---
 
 ## よく使うコマンドまとめ

--- a/posts/2023-03-20/index.md
+++ b/posts/2023-03-20/index.md
@@ -2,7 +2,6 @@
 title: "AsyncIteratorでデータを一括ではなく順次取得する"
 tags: ["TypeScript","npm"]
 slug: iterator-of-typescript
-coverImage:
 ---
 
 TypeScriptでAsyncIterableIteratorを使おうとしたら見たことない記述が多かったのでまとめた。

--- a/posts/2026-08-02/index.md
+++ b/posts/2026-08-02/index.md
@@ -2,7 +2,6 @@
 title: "数年止まったNext.jsブログを、履歴を残して再構築した"
 tags: ["Next.js", "TypeScript", "設計", "メンテナンス"]
 slug: blog-reboot-2026
-coverImage: ""
 summary: "更新が止まった個人ブログを、リポジトリを作り直さずにNext.js 16へ更新し、また書き続けられる形へ再設計した判断と手順をまとめます。"
 publishedAt: "2026-08-02"
 featured: false

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server"
+
+const legacySlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+export function proxy(request: NextRequest) {
+  const legacySlug = request.nextUrl.searchParams.get("slug")
+  if (!legacySlug || !legacySlugPattern.test(legacySlug)) return NextResponse.next()
+
+  const destination = request.nextUrl.clone()
+  destination.pathname = `/articles/${legacySlug}`
+  destination.search = ""
+  destination.hash = ""
+  return NextResponse.redirect(destination, 308)
+}
+
+export const config = { matcher: "/" }

--- a/src/components/client/ArticleExperience/ArticleExperience.tsx
+++ b/src/components/client/ArticleExperience/ArticleExperience.tsx
@@ -2,11 +2,7 @@
 
 import { lazy, Suspense, useLayoutEffect, useState, useSyncExternalStore } from "react"
 
-import type {
-  ArticleExperienceData,
-  ReaderOrientation,
-  ReaderTheme,
-} from "@/components/article-experience/types"
+import type { ArticleExperienceData, ReaderOrientation, ReaderTheme } from "@/components/article-experience/types"
 import { ArticleReader } from "./ArticleReader"
 
 const DesktopArticleExperience = lazy(() => import("./DesktopArticleExperience"))
@@ -132,7 +128,9 @@ function DesktopReaderBootstrap({ data }: { data: ArticleExperienceData }) {
               <div className="device-screen-layer bootstrap-reader-screen">
                 <div className="bootstrap-reader-header">
                   <i />
-                  <b>sena-v<span>.</span>com</b>
+                  <b>
+                    sena-v<span>.</span>com
+                  </b>
                   <i />
                 </div>
                 <div className="bootstrap-reader-copy">
@@ -203,9 +201,7 @@ export function ArticleExperienceClient({ data }: { data: ArticleExperienceData 
 
   return (
     <main id="main-content" className="desktop-reader-page">
-      <Suspense
-        fallback={<DesktopReaderBootstrap data={data} />}
-      >
+      <Suspense fallback={<DesktopReaderBootstrap data={data} />}>
         <DesktopArticleExperience
           data={data}
           theme={theme}

--- a/src/components/client/Ga4/Ga4.tsx
+++ b/src/components/client/Ga4/Ga4.tsx
@@ -1,7 +1,50 @@
+"use client"
+
 import Script from "next/script"
+import { usePathname } from "next/navigation"
+import { useEffect, useRef } from "react"
+
+import { buildGa4PageLocation } from "@/lib/analytics/ga4"
+import { siteUrl } from "@/utils/constants"
 
 type Ga4Props = {
   measurementId: string
+}
+
+function Ga4PageViews({ measurementId }: Ga4Props) {
+  const pathname = usePathname()
+  const lastSentPathname = useRef<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const sendPageView = () => {
+      if (cancelled || !window.gtag || lastSentPathname.current === pathname) return
+      const pageLocation = buildGa4PageLocation(siteUrl, pathname)
+      lastSentPathname.current = pathname
+      window.gtag("event", "page_view", {
+        page_location: pageLocation,
+        page_path: pathname,
+        page_title: document.title,
+      })
+    }
+
+    if (window.gtag) {
+      const timer = window.setTimeout(sendPageView, 0)
+      return () => {
+        cancelled = true
+        window.clearTimeout(timer)
+      }
+    }
+
+    window.addEventListener("sena-v-ga4-ready", sendPageView, { once: true })
+    return () => {
+      cancelled = true
+      window.removeEventListener("sena-v-ga4-ready", sendPageView)
+    }
+  }, [measurementId, pathname])
+
+  return null
 }
 
 export function Ga4({ measurementId }: Ga4Props) {
@@ -11,11 +54,14 @@ export function Ga4({ measurementId }: Ga4Props) {
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
+          window.gtag = gtag;
           gtag('js', new Date());
           gtag('config', '${measurementId}', {
+            send_page_view: false,
             allow_google_signals: false,
             allow_ad_personalization_signals: false
           });
+          window.dispatchEvent(new Event('sena-v-ga4-ready'));
         `}
       </Script>
       <Script
@@ -23,6 +69,7 @@ export function Ga4({ measurementId }: Ga4Props) {
         strategy="afterInteractive"
         src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
       />
+      <Ga4PageViews measurementId={measurementId} />
     </>
   )
 }

--- a/src/lib/analytics/ga4.test.ts
+++ b/src/lib/analytics/ga4.test.ts
@@ -1,7 +1,22 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 
-import { resolveGa4MeasurementId } from "./ga4.ts"
+import { buildGa4PageLocation, resolveGa4MeasurementId } from "./ga4.ts"
+
+test("page locationからqueryとfragmentを除外する", () => {
+  assert.equal(
+    buildGa4PageLocation("https://sena-v.com", "/writings?query=private%20search&tags=React#results"),
+    "https://sena-v.com/writings",
+  )
+  assert.equal(
+    buildGa4PageLocation("https://sena-v.com", "/articles/package-manager-node"),
+    "https://sena-v.com/articles/package-manager-node",
+  )
+  assert.equal(
+    buildGa4PageLocation("https://sena-v.com", "//attacker.example/secret?query=private"),
+    "https://sena-v.com/secret",
+  )
+})
 
 test("Vercel Productionでは有効なMeasurement IDを返す", () => {
   assert.equal(resolveGa4MeasurementId({ measurementId: "G-ABC123", vercelEnvironment: "production" }), "G-ABC123")

--- a/src/lib/analytics/ga4.ts
+++ b/src/lib/analytics/ga4.ts
@@ -6,6 +6,12 @@ type Ga4Environment = {
   vercelEnvironment?: string
 }
 
+export function buildGa4PageLocation(origin: string, path: string) {
+  const canonicalOrigin = new URL(origin).origin
+  const location = new URL(path, origin)
+  return `${canonicalOrigin}${location.pathname}`
+}
+
 export function resolveGa4MeasurementId({
   explicitlyEnabled,
   measurementId,

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -7,6 +7,8 @@ import {
   getWritingArchives,
   getWritingBySlug,
   validateCoverImage,
+  validateFrontmatterKeys,
+  validateOptionalBoolean,
   validateWritingDate,
   validateWritingSlug,
 } from "./content.ts"
@@ -26,10 +28,24 @@ test("content identifierはURL・日付・画像rootの境界を越えない", (
   assert.throws(() => validateCoverImage("missing.png"), /existing file/)
 })
 
+test("frontmatterの未知フィールドと曖昧なbooleanを公開扱いにしない", () => {
+  assert.doesNotThrow(() => validateFrontmatterKeys({ title: "Article", draft: true }, ["title", "draft"]))
+  assert.throws(
+    () => validateFrontmatterKeys({ title: "Article", drfat: true }, ["title", "draft"], "fixture.md"),
+    /Unknown frontmatter field drfat: fixture\.md/,
+  )
+  assert.equal(validateOptionalBoolean(undefined, "draft"), false)
+  assert.equal(validateOptionalBoolean(true, "draft"), true)
+  assert.throws(() => validateOptionalBoolean("true", "draft", "fixture.md"), /draft must be a boolean/)
+})
+
 test("archiveは新しい月から並び、件数を保持する", () => {
   const archives = getWritingArchives()
   assert.ok(archives.length > 0)
-  assert.deepEqual([...archives].sort(([left], [right]) => right.localeCompare(left)), archives)
+  assert.deepEqual(
+    [...archives].sort(([left], [right]) => right.localeCompare(left)),
+    archives,
+  )
   assert.ok(archives.every(([month, count]) => /^\d{4}-\d{2}$/.test(month) && count > 0))
 })
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -28,6 +28,31 @@ const externalDirectory = path.join(process.cwd(), "content", "external")
 const publicImagesDirectory = path.join(process.cwd(), "public", "images")
 const writingSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const writingDatePattern = /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2}))?$/
+const localFrontmatterKeys = [
+  "title",
+  "slug",
+  "summary",
+  "tags",
+  "coverImage",
+  "publishedAt",
+  "updatedAt",
+  "relatedSlugs",
+  "featured",
+  "draft",
+] as const
+const externalFrontmatterKeys = [
+  "title",
+  "slug",
+  "summary",
+  "publishedAt",
+  "updatedAt",
+  "importedAt",
+  "tags",
+  "externalUrl",
+  "platform",
+  "featured",
+  "draft",
+] as const
 
 const parseFrontmatter = (source: string, filePath: string) => {
   const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source)
@@ -58,9 +83,32 @@ const requiredString = (data: Record<string, unknown>, key: string, filePath: st
   return value.trim()
 }
 
-const optionalString = (data: Record<string, unknown>, key: string) => {
+const optionalString = (data: Record<string, unknown>, key: string, filePath: string) => {
   const value = data[key]
-  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined
+  if (value === undefined) return undefined
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${key} must be a non-empty string when provided: ${filePath}`)
+  }
+  return value.trim()
+}
+
+export const validateFrontmatterKeys = (
+  data: Record<string, unknown>,
+  allowedKeys: readonly string[],
+  filePath = "content",
+) => {
+  const unknownKeys = Object.keys(data).filter((key) => !allowedKeys.includes(key))
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Unknown frontmatter field${unknownKeys.length === 1 ? "" : "s"} ${unknownKeys.join(", ")}: ${filePath}`,
+    )
+  }
+}
+
+export const validateOptionalBoolean = (value: unknown, key: string, filePath = "content") => {
+  if (value === undefined) return false
+  if (typeof value !== "boolean") throw new Error(`${key} must be a boolean when provided: ${filePath}`)
+  return value
 }
 
 export const validateWritingSlug = (value: string, filePath = "content") => {
@@ -80,9 +128,9 @@ export const validateWritingDate = (value: string, key = "date", filePath = "con
   const [, year, month, day] = match
   const calendarDate = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
   if (
-    calendarDate.getUTCFullYear() !== Number(year)
-    || calendarDate.getUTCMonth() + 1 !== Number(month)
-    || calendarDate.getUTCDate() !== Number(day)
+    calendarDate.getUTCFullYear() !== Number(year) ||
+    calendarDate.getUTCMonth() + 1 !== Number(month) ||
+    calendarDate.getUTCDate() !== Number(day)
   ) {
     throw new Error(`${key} must be a real calendar date: ${filePath}`)
   }
@@ -93,10 +141,10 @@ export const validateWritingDate = (value: string, key = "date", filePath = "con
 export const validateCoverImage = (value: string, filePath = "content") => {
   const segments = value.split("/")
   if (
-    value.startsWith("/")
-    || value.includes("\\")
-    || /[?#\0]/.test(value)
-    || segments.some((segment) => segment === "" || segment === "." || segment === "..")
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    /[?#\0]/.test(value) ||
+    segments.some((segment) => segment === "" || segment === "." || segment === "..")
   ) {
     throw new Error(`coverImage must be a relative path below public/images: ${filePath}`)
   }
@@ -122,7 +170,7 @@ const requiredDate = (data: Record<string, unknown>, key: string, filePath: stri
   validateWritingDate(requiredString(data, key, filePath), key, filePath)
 
 const optionalDate = (data: Record<string, unknown>, key: string, filePath: string) => {
-  const value = optionalString(data, key)
+  const value = optionalString(data, key, filePath)
   return value ? validateWritingDate(value, key, filePath) : undefined
 }
 
@@ -177,14 +225,19 @@ const getLocalWritings = (): Writing[] => {
       const filePath = path.join(postsDirectory, entry.name, "index.md")
       const source = fs.readFileSync(filePath, "utf8")
       const { data, content } = parseFrontmatter(source, filePath)
-      const coverImage = optionalString(data, "coverImage")
-      const publishedAt = validateWritingDate(optionalString(data, "publishedAt") ?? entry.name, "publishedAt", filePath)
+      validateFrontmatterKeys(data, localFrontmatterKeys, filePath)
+      const coverImage = optionalString(data, "coverImage", filePath)
+      const publishedAt = validateWritingDate(
+        optionalString(data, "publishedAt", filePath) ?? entry.name,
+        "publishedAt",
+        filePath,
+      )
 
       return {
         kind: "local" as const,
         slug: requiredSlug(data, filePath),
         title: requiredString(data, "title", filePath),
-        summary: optionalString(data, "summary") ?? makeSummary(content),
+        summary: optionalString(data, "summary", filePath) ?? makeSummary(content),
         publishedAt,
         updatedAt: optionalDate(data, "updatedAt", filePath),
         tags: stringArray(data, "tags", filePath),
@@ -193,8 +246,8 @@ const getLocalWritings = (): Writing[] => {
         relatedSlugs: optionalStringArray(data, "relatedSlugs", filePath)?.map((slug) =>
           validateWritingSlug(slug, filePath),
         ),
-        featured: data.featured === true,
-        draft: data.draft === true,
+        featured: validateOptionalBoolean(data.featured, "featured", filePath),
+        draft: validateOptionalBoolean(data.draft, "draft", filePath),
       }
     })
 }
@@ -209,6 +262,7 @@ const getExternalWritings = (): Writing[] => {
       const filePath = path.join(externalDirectory, fileName)
       const source = fs.readFileSync(filePath, "utf8")
       const { data } = parseFrontmatter(source, filePath)
+      validateFrontmatterKeys(data, externalFrontmatterKeys, filePath)
 
       return {
         kind: "external" as const,
@@ -221,8 +275,8 @@ const getExternalWritings = (): Writing[] => {
         tags: stringArray(data, "tags", filePath),
         externalUrl: requiredHttpUrl(data, "externalUrl", filePath),
         platform: requiredString(data, "platform", filePath),
-        featured: data.featured === true,
-        draft: false,
+        featured: validateOptionalBoolean(data.featured, "featured", filePath),
+        draft: validateOptionalBoolean(data.draft, "draft", filePath),
       }
     })
 }
@@ -244,8 +298,7 @@ export const getAllWritings = () => {
 
 export const getLocalWritingsOnly = () => getAllWritings().filter((writing) => writing.kind === "local")
 
-export const getWritingBySlug = (slug: string) =>
-  getLocalWritingsOnly().find((writing) => writing.slug === slug)
+export const getWritingBySlug = (slug: string) => getLocalWritingsOnly().find((writing) => writing.slug === slug)
 
 export const getRelatedWritings = (current: Writing, limit = 8) => {
   const candidates = getAllWritings().filter((writing) => writing.slug !== current.slug)


### PR DESCRIPTION
## Stack

1 of 3 stacked hardening PRs. Base: `feature/blog-reboot-2026`.

Merge this PR before the quality and defense-in-depth PRs that follow.

## What changed

- keeps `https://sena-v.com` as the canonical origin and points production smoke checks at the apex host
- makes the server bootstrap and hydrated reader header geometrically stable across repeated reloads
- preserves lazy WebGL/desktop loading while preventing header controls from jumping
- moves the legacy `?slug=` redirect into a same-origin, allowlisted Next.js proxy and strips all query parameters
- makes the home and article routes 12-hour ISR pages so GA4 popular ordering can refresh
- changes GA4 to pathname-only manual page views with duplicate suppression and no query/fragment data
- rejects unknown frontmatter keys and non-boolean `draft`/`featured` values instead of publishing fail-open
- removes empty legacy cover fields and updates the release/design/GA4 documentation
- removes `legacy-peer-deps`, installs a compatible root `picomatch`, and restores a valid dependency tree

## Adversarial review

- valid legacy slugs return a same-origin 308 without query parameters
- traversal, protocol-relative, CRLF, and malformed slug values do not redirect
- analytics page locations are pinned to the canonical apex origin and omit query/fragment data
- draft and unknown frontmatter fields fail closed
- reload geometry is checked for the device, theme toggle, hamburger, and wordmark across five reloads
- lockfile registry origins, package signatures, dependency integrity, secrets, and unsafe URL patterns were reviewed

## Verification

- `npm ci`
- `npm run ci`
- `npm ls --all`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm audit signatures` — 451 verified signatures, 76 attestations
- Playwright — 21/21 passed against `next build` + `next start`
- production build — 77 pages; `/` and article pages show 12-hour revalidation

## Deferred external settings

These do not block the remaining stacked PR work and are collected for the final handoff:

- make `sena-v.com` the Vercel Primary Domain and redirect `www` to apex
- disable GA4 browser-history page views before enabling the manual page-view implementation in production
- apply verified `main` branch protection after all stacked PRs exist
