### PR TITLE
fix: improve blog quality safeguards

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container:
       image: mcr.microsoft.com/playwright:v1.62.1-jammy@sha256:b3251f7ff1a9fa559a28d1c67eaa15fc1a9800f7845e82756caea7842967f615
     steps:
@@ -23,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies
@@ -33,7 +34,7 @@ jobs:
         shell: bash
         run: |
           for attempt in {1..60}; do
-            deployed_sha="$(curl --location --fail --silent --show-error https://sena-v.com/version || true)"
+            deployed_sha="$(curl --location --fail --silent --show-error --connect-timeout 5 --max-time 10 https://sena-v.com/version || true)"
             if [ "$deployed_sha" = "$GITHUB_SHA" ]; then
               exit 0
             fi

--- a/.github/workflows/precheck-code.yml
+++ b/.github/workflows/precheck-code.yml
@@ -15,6 +15,7 @@ jobs:
   quality:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -22,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies
@@ -31,12 +32,15 @@ jobs:
       - name: Lint, typecheck, and build
         run: npm run ci
 
-      - name: Audit production dependencies
-        run: npm audit --omit=dev --audit-level=high
+      - name: Audit dependency graph and signatures
+        run: |
+          npm audit --audit-level=high
+          npm audit signatures
 
   e2e:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container:
       image: mcr.microsoft.com/playwright:v1.62.1-jammy@sha256:b3251f7ff1a9fa559a28d1c67eaa15fc1a9800f7845e82756caea7842967f615
     steps:
@@ -46,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 24
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm run check:links:external
 npm audit
 ```
 
-Pull requests run the quality and E2E suites on Node.js 24. A smoke test runs against the production domain after changes reach `main`.
+Pull requests run the quality and E2E suites with the Node.js version pinned in `.nvmrc`, enforce job timeouts, and audit the complete dependency graph. A smoke test runs against the production domain after changes reach `main`.
 
 ## Content model
 

--- a/app/writings/page.tsx
+++ b/app/writings/page.tsx
@@ -103,6 +103,7 @@ export default async function WritingsPage({ searchParams }: WritingsPageProps) 
                 <Link
                   className="tag-filter-clear"
                   href={tagsClearHref}
+                  prefetch={false}
                   aria-label="選択中のタグをすべて解除"
                 >
                   タグ解除
@@ -122,7 +123,7 @@ export default async function WritingsPage({ searchParams }: WritingsPageProps) 
                   <span>複数選択・AND検索</span>
                 </div>
                 <div className="tag-filter-popover-actions">
-                  {selectedTags.length > 0 && <Link href={tagsClearHref}>すべて外す</Link>}
+                  {selectedTags.length > 0 && <Link href={tagsClearHref} prefetch={false}>すべて外す</Link>}
                   <button
                     type="button"
                     popoverTarget="writings-tag-filter"
@@ -178,6 +179,7 @@ export default async function WritingsPage({ searchParams }: WritingsPageProps) 
                     <Link
                       key={tag}
                       href={buildWritingsHref({ ...filters, tags: selectedTags.filter((item) => item !== tag) })}
+                      prefetch={false}
                       aria-label={`${tag}のタグ絞り込みを解除`}
                     >
                       #{tag}<span aria-hidden="true">×</span>
@@ -185,7 +187,7 @@ export default async function WritingsPage({ searchParams }: WritingsPageProps) 
                   ))}
                 </span>
               )}
-              <Link href="/writings">すべて解除</Link>
+              <Link href="/writings" prefetch={false}>すべて解除</Link>
             </>
           )}
         </div>

--- a/docs/design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md
+++ b/docs/design-research/round-5-article-cover-engineering/FIRST_FINAL_DESIGN_SPEC.md
@@ -142,6 +142,7 @@ iconは現在の向きではなく、押した後に到達する向きを示す�
 
 - portrait state: 横長phone icon + `横`、`aria-label="横表示へ切り替える"`
 - landscape state: 縦長phone icon + `縦`、`aria-label="縦表示へ切り替える"`
+- buttonのaccessible nameは到達先、`aria-describedby`は現在の向きを示す。toggleの押下状態ではないため`aria-pressed`は使わない。
 
 ### 外観と位置
 
@@ -205,6 +206,7 @@ native scrollの挙動を維持し、wheel、trackpad、touch drag、scrollbar d
 - tagは角丸cardの反復ではなく、記事本文と同じ`#tag`表現を使う。
 - heroの総数は裸の数字にせず、`記事数 36`のように単位と意味を明示する。
 - 1280px幅の初見で見出し、検索、絞り込み、先頭記事まで到達できる密度にする。
+- 一覧に反復する記事・tag・filter linkは自動prefetchを無効にし、画面表示だけで数十件のRSC requestを発生させない。global navigationの少数の主要linkはprefetchを維持する。
 
 ### About
 

--- a/docs/design-research/round-5-article-cover-engineering/IMPLEMENTATION_VERIFICATION.md
+++ b/docs/design-research/round-5-article-cover-engineering/IMPLEMENTATION_VERIFICATION.md
@@ -1,7 +1,7 @@
 # Article cover implementation verification
 
 検証日: 2026-08-04
-対象branch: `feature/blog-reboot-critical-fixes`
+対象branch: `feature/blog-reboot-quality-fixes`
 対象URL: localhost (`next build` + `next start`)
 
 ## 仕様チェック
@@ -13,6 +13,7 @@
 - portrait/landscapeのlayout長辺・短辺比はともに `2.08623`、E2E許容誤差は0.001未満。端末は静止時に正面・左右対称へ戻り、fine pointer操作中だけshell全体が最大X 2.4° / Y 3.8°で傾く。
 - landscapeからの「縦表示へ切り替える」操作を常時表示する。
 - 端末方向はpresentation上の一時状態として扱い、reload・再訪・別記事では必ずportraitから開始する。themeだけを継続設定として保存し、landscapeを既定表示にしない。
+- orientation controlとtheme toggleはaccessible nameに到達先、関連付けた説明に現在状態を持たせ、動作の意味と合わない`aria-pressed`は付けない。
 - CSSとWebGLは短辺比3.2%の均一bezelを使い、内側radiusを外側radiusからbezel幅だけ引いて同心にする。1619×886 viewportではportrait bezelが上下左右約19.77px、landscapeが約17.17px。graphite rim、端末自身のshadow、中央対称の弱いaccent lightにより黒背景上でもbezelを識別できる。offsetした背面layerは置かない。
 - bezelの基準色は操作前後で同じCSS material layerが持ち、lazy WebGLは上から16%の弱いscreen blendで光沢だけを追加する。CSS fallbackからWebGLへ切り替わっても基準gradientは変えず、縦横往復後もcomputed backgroundと実画像が一致する。pointer位置はReact renderを介さずCSS custom propertyへ渡し、neutral highlightをbezel上で左右・上下に追従させる。
 - 端末内側に白borderを置かず、WebGL screenは照明を反射しない黒材質にする。縦横切替中はlive DOMとCSS rimを`visibility:hidden`でも遮断し、外装の反射も白ではなくgraphiteに抑えてinset・角丸の変形途中を見せない。
@@ -28,6 +29,7 @@
 - desktopのdrawerは`show()`を使って端末screen内だけを覆う左側sheetにし、portrait/landscapeともhamburgerと同じ左方向から表示する。close buttonはdrawer左上の44px targetとし、hamburgerとの横中心差を16px未満にする。3本線hamburgerへpointer/focusが入った瞬間の端末transformを固定し、開閉によるheader方向への位置ずれを防ぐ。外側は`overflow:clip`、focus復帰は`preventScroll`を使い、Escape・見出し移動後のfocusを維持する。theme変更は常時見えるheaderに一元化し、drawer内の重複controlは置かない。端末内wordmarkのdotはpink、theme iconはactive SVG自体を18px knob内部のgrid中央へ置き、座標補正に依存しない。実smartphone drawerも左側全高sheet、カード型navigation、番号付き目次、関連記事を持つ。
 - reader wordmarkは17px以上、44pxの操作領域を持つbuttonとする。wordmarkまたはheader空白面から、desktopでは端末内reader、smartphoneではdocumentを先頭へ戻す。menu・theme操作では誤発火せず、reduced motionではsmooth scrollを使わない。
 - Writingsのtag絞り込みはpopoverで複数選択・AND検索を行い、選択中tagの個別解除・一括解除、query/archive条件の維持を行う。
+- Writingsと周辺索引の反復linkは自動prefetchを止め、主要global navigationの少数linkだけを先読みする。
 - Writings heroは総数を`記事数 36`と明記し、裸の数字だけを表示しない。
 - Aboutは「書いていること」と外部・記事一覧linkへ絞り、説明的な方針sectionを置かない。global headerはwordmarkとは別に`ホーム`を明示し、390px幅でも3リンクを横overflowさせない。
 - 外側左railは主見出しをeyebrowの1.6倍以上にし、`SENA-V.COM / READING DESK`へ18pxのpink ruleを付ける。主題と文脈labelを同じ強さにせず、意図的なhierarchyとして見せる。
@@ -50,15 +52,15 @@
 | --- | --- |
 | ESLint | pass、warning 0 |
 | TypeScript | pass |
-| Unit tests | 13 / 13 pass |
+| Unit tests | 16 / 16 pass |
 | Internal content/link validation | Markdown source 37件（公開36件）、slug 37件、external URL 51件を検証 |
 | Production build | pass、77 pages |
-| Playwright E2E | 21 / 21 pass（hard reload初期HTML・不正archive値の無効化を含む。目次focusは並列10回反復もpass） |
+| Playwright E2E | 22 / 22 pass（hard reload初期HTML・不正archive値・反復linkのRSC prefetch抑制を含む。目次focusは並列10回反復もpass） |
 | npm dependency audit | 0 vulnerabilities |
 | `git diff --check` | pass |
 | In-app browser console | error / warning 0（WebGL起動後を含む） |
 
-E2Eには端末比率、縦64%表示、縦横切替、reload時のportrait復帰とtheme保持、WebGL準備待ち、操作前後・縦横往復後のbezel基準色、pointer追従highlight、回転中のDOM/rim非表示、pointer左右追従とleave時のspring-back、外側scroll固定、左右285px rail、見出し比率1.6倍以上と18px eyebrow rule、orientation controlの両側gutterと1600ms SVG円周animation、均一bezel、light theme contrast・toggle中心・drawer配色、3本線hamburger・左上44px close・drawer内theme control 0件・17px以上のpink-dot wordmark・headerからのscroll-to-top・knob内icon中心0px、return control、索引文字サイズ、1280×720 landscape本文サイズ、30px rabbit outlineと44px hit area、Writingsの複数tag AND検索・個別解除・記事数表記、Writings/Aboutの初見密度、About方針section不在、global `ホーム`導線と390px header収まり、Archive専用高さ・2019.12の4行separator・外部サイト表記、3種の内部遷移中SP flash不在、draftのsitemap除外、端末screen内drawerと開閉前後0.5px未満の位置固定、Tab focus trap・Escape・見出しfocus、reduced motion時のtilt無効化、WebGL fallback、smartphoneでのcanvas不在・横overflow不在、responsive画像、redirect、SEO metadata、security headers、privacy/analytics条件を含む。
+E2Eには端末比率、縦64%表示、縦横切替、切替controlの現在状態説明、reload時のportrait復帰とtheme保持、WebGL準備待ち、操作前後・縦横往復後のbezel基準色、pointer追従highlight、回転中のDOM/rim非表示、pointer左右追従とleave時のspring-back、外側scroll固定、左右285px rail、見出し比率1.6倍以上と18px eyebrow rule、orientation controlの両側gutterと1600ms SVG円周animation、均一bezel、light theme contrast・toggle中心・drawer配色、3本線hamburger・左上44px close・drawer内theme control 0件・17px以上のpink-dot wordmark・headerからのscroll-to-top・knob内icon中心0px、return control、索引文字サイズ、1280×720 landscape本文サイズ、30px rabbit outlineと44px hit area、Writingsの複数tag AND検索・個別解除・記事数表記・反復linkのRSC prefetch抑制、Writings/Aboutの初見密度、About方針section不在、global `ホーム`導線と390px header収まり、Archive専用高さ・2019.12の4行separator・外部サイト表記、3種の内部遷移中SP flash不在、draftのsitemap除外、端末screen内drawerと開閉前後0.5px未満の位置固定、Tab focus trap・Escape・見出しfocus、reduced motion時のtilt無効化、WebGL fallback、smartphoneでのcanvas不在・横overflow不在、responsive画像、redirect、SEO metadata、security headers、privacy/analytics条件を含む。
 
 ## 受け入れ条件対応表
 
@@ -67,7 +69,7 @@ E2Eには端末比率、縦64%表示、縦横切替、reload時のportrait復帰
 | 同一mesh・外装比率誤差0.001以内 | portrait / landscapeのcomputed ratioをE2E計測 | pass |
 | landscapeはuniform scale `1.2369924` | DOM属性、R3F groupの単一`setScalar`、E2E | pass |
 | portrait → landscape → portrait | 両方向button操作と状態維持E2E | pass |
-| 回転buttonは右側に1個、到達先を表示 | button count、`aria-label`、実座標をE2E計測 | pass |
+| 回転buttonは右側に1個、到達先と現在状態を表示 | button count、`aria-label`、`aria-describedby`、実座標をE2E計測 | pass |
 | theme toggleを縦横で維持 | 切替・回転・reload後の属性をE2E確認 | pass |
 | portraitの左右索引 / landscapeの3索引 | DOM件数、実JPEG、scroll領域を確認 | pass |
 | next row・mask・rail・rabbit thumb | native scroll、mask、keyboard、ARIA scrollbar、SVG styleをE2E確認 | pass |
@@ -77,7 +79,7 @@ E2Eには端末比率、縦64%表示、縦横切替、reload時のportrait復帰
 | smartphoneは外装なしで同じreader | 390×844でdesktop/canvas 0、mobile reader 1 | pass |
 | PV・GA credentialをclientへ出さない | server-only module、secret scan、公開payload review | pass |
 | WebGL / GA4障害時も閲覧可能 | CSS fallback E2E、静的新着fallback unit test | pass |
-| screenshot・操作・fallback test | In-app Browser実操作、Playwright 21 / 21 | pass |
+| screenshot・操作・fallback test | In-app Browser実操作、Playwright 22 / 22 | pass |
 
 ## Lighthouse 13.4.1
 
@@ -99,7 +101,7 @@ WebGLはhover後にcanvas 1件・readyとなり、pointer位置に応じてtilt�
 ## セキュリティ・privacyレビュー
 
 - CSP、HSTS、`X-Content-Type-Options`、`Referrer-Policy`、`Permissions-Policy`、COOP/CORP、frame拒否headerをproduction responseで検証した。
-- 外部記事frontmatterのURLはabsolute HTTP(S)だけを受理し、外部linkは `noopener noreferrer` と新規tab表記を持つ。
+- 外部記事frontmatterのURLはcredentialを含まないabsolute HTTPSだけを受理し、外部linkは `noopener noreferrer` と新規tab表記を持つ。
 - GA4とSpeed InsightsはVercel production以外では自動読込しない。GA4 page viewはqueryを除いたcanonical pathnameだけを手動送信し、管理画面の履歴変更page viewを無効にする。
 - GA4 service account secretは環境変数のみで扱い、client payloadはslugとfallback/GA4 sourceだけを受け取る。
 - credential形式のsecret scanでは `.env.example` の説明用placeholder以外を検出していない。

--- a/e2e/playwright/site.spec.ts
+++ b/e2e/playwright/site.spec.ts
@@ -68,7 +68,10 @@ test("トップページが実記事を中心にしたdesktop readerを表示す
   await expect(page.locator(".desktop-experience")).toHaveAttribute("data-orientation", "portrait")
   await expect(page.locator(".article-reader .reader-article-header h1")).toBeVisible()
   await expect(page.locator(".orientation-control")).toHaveCount(1)
-  await expect(page.getByRole("button", { name: "横表示へ切り替える" })).toBeVisible()
+  const orientationButton = page.getByRole("button", { name: "横表示へ切り替える" })
+  await expect(orientationButton).toBeVisible()
+  await expect(orientationButton).not.toHaveAttribute("aria-pressed")
+  await expect(orientationButton).toHaveAccessibleDescription("現在は縦表示")
   await expect(page.locator(".reader-menu-button span")).toHaveCount(3)
   expect(await page.locator(".reader-brand-dot").evaluate((element) => ({
     actual: getComputedStyle(element).color,
@@ -88,6 +91,9 @@ test("トップページが実記事を中心にしたdesktop readerを表示す
   })
   expect(themeIconCentering.x).toBeLessThan(0.01)
   expect(themeIconCentering.y).toBeLessThan(0.01)
+  const themeButton = page.locator(".theme-toggle")
+  await expect(themeButton).not.toHaveAttribute("aria-pressed")
+  await expect(themeButton).toHaveAccessibleDescription(/現在は(ダーク|ライト)モード/)
   const visualHierarchy = await page.locator(".device-shell").evaluate((element) => {
     const box = element.getBoundingClientRect()
     const rim = getComputedStyle(element, "::before")
@@ -326,7 +332,9 @@ test("同一比率の端末をuniform scaleで縦横切替し、reader状態を�
   await expect(experience).toHaveAttribute("data-webgl-mode", "webgl")
   await expect(page.locator("canvas")).toHaveCount(1, { timeout: 15_000 })
   await expect(experience).toHaveAttribute("data-device-uniform-scale", "1.2369924")
-  await expect(page.getByRole("button", { name: "縦表示へ切り替える" })).toBeEnabled()
+  const portraitReturnButton = page.getByRole("button", { name: "縦表示へ切り替える" })
+  await expect(portraitReturnButton).toBeEnabled()
+  await expect(portraitReturnButton).toHaveAccessibleDescription("現在は横表示")
   await expect(experience).not.toHaveClass(/is-rotating/, { timeout: 5_000 })
   const transitionSamples = await page.evaluate(() => {
     type TransitionSample = { state: string | null; ready: string | null; visualVisibility: string; rimVisibility: string; screenVisibility: string }
@@ -384,6 +392,9 @@ test("同一比率の端末をuniform scaleで縦横切替し、reader状態を�
   const themeButtonName = startedDark ? "ライトモードへ切り替える" : "ダークモードへ切り替える"
   await page.getByRole("button", { name: themeButtonName }).click()
   await expect(reader).toHaveAttribute("data-reader-theme", nextTheme)
+  await expect(page.locator(".theme-toggle")).toHaveAccessibleDescription(
+    `現在は${nextTheme === "dark" ? "ダーク" : "ライト"}モード`,
+  )
   await page.reload()
   await expect(page.locator(".desktop-experience")).toHaveAttribute("data-orientation", "portrait")
   await expect(page.locator(".article-reader")).toHaveAttribute("data-reader-theme", nextTheme)
@@ -862,6 +873,26 @@ test("記事一覧をGETパラメータとarchiveで検索できる", async ({ p
   await expect(page).toHaveURL(/query=%E3%83%91%E3%83%83%E3%82%B1%E3%83%BC%E3%82%B8/)
   await expect(page.getByText("すべて解除")).toBeVisible()
   await expect(page.locator(".writing-timeline-entry").first()).toBeVisible()
+})
+
+test("記事一覧の反復リンクは表示だけでRSCを一括prefetchしない", async ({ page }) => {
+  const repeatedLinkPrefetches: string[] = []
+  page.on("request", (request) => {
+    const requestUrl = new URL(request.url())
+    const isRscRequest = request.headers().rsc === "1" || requestUrl.searchParams.has("_rsc")
+    const writingsFilterKeys = [...requestUrl.searchParams.keys()].filter((key) => key !== "_rsc")
+    const isRepeatedDestination = (
+      requestUrl.pathname.startsWith("/articles/")
+      || requestUrl.pathname.startsWith("/tags/")
+      || (requestUrl.pathname === "/writings" && writingsFilterKeys.length > 0)
+    )
+    if (isRscRequest && isRepeatedDestination) repeatedLinkPrefetches.push(request.url())
+  })
+
+  await page.goto("/writings")
+  await page.waitForTimeout(1_800)
+
+  expect(repeatedLinkPrefetches).toEqual([])
 })
 
 test("記事一覧で複数タグをAND検索し、個別解除しても他の条件を残せる", async ({ page }) => {

--- a/src/components/WritingCard.tsx
+++ b/src/components/WritingCard.tsx
@@ -37,7 +37,7 @@ export function WritingCard({ writing }: { writing: Writing }) {
   }
 
   return (
-    <Link className="writing-card" href={`/articles/${writing.slug}`}>
+    <Link className="writing-card" href={`/articles/${writing.slug}`} prefetch={false}>
       {cardBody}
     </Link>
   )

--- a/src/components/WritingTimeline.tsx
+++ b/src/components/WritingTimeline.tsx
@@ -26,7 +26,7 @@ export function WritingTimeline({ writings }: { writings: Writing[] }) {
                 <span className="sr-only">（新しいタブで開く）</span>
               </a>
             ) : (
-              <Link className="timeline-title" href={`/articles/${writing.slug}`}>
+              <Link className="timeline-title" href={`/articles/${writing.slug}`} prefetch={false}>
                 {writing.title}
               </Link>
             )}
@@ -38,7 +38,7 @@ export function WritingTimeline({ writings }: { writings: Writing[] }) {
           <ul className="tag-list" aria-label="タグ">
             {writing.tags.map((tag) => (
               <li key={tag}>
-                <Link className="tag-link" href={`/tags/${encodeURIComponent(tag)}`}>{tag}</Link>
+                <Link className="tag-link" href={`/tags/${encodeURIComponent(tag)}`} prefetch={false}>{tag}</Link>
               </li>
             ))}
           </ul>

--- a/src/components/client/ArticleExperience/ArticleReader.tsx
+++ b/src/components/client/ArticleExperience/ArticleReader.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react"
+import { useEffect, useId, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react"
 
 import { MarkdownArticle } from "@/components/MarkdownArticle"
 import type {
@@ -44,6 +44,7 @@ export function ArticleReader({
   const contentRef = useRef<HTMLDivElement>(null)
   const restoreTriggerFocusRef = useRef(true)
   const onMenuStateChangeRef = useRef(onMenuStateChange)
+  const themeStatusId = useId()
   const headings = useMemo(() => extractMarkdownHeadings(writing.content), [writing.content])
 
   useEffect(() => {
@@ -200,7 +201,7 @@ export function ArticleReader({
           type="button"
           onClick={() => onThemeChange(nextTheme)}
           aria-label={`${nextTheme === "dark" ? "ダーク" : "ライト"}モードへ切り替える`}
-          aria-pressed={theme === "dark"}
+          aria-describedby={themeStatusId}
           title={`${nextTheme === "dark" ? "ダーク" : "ライト"}モードへ`}
         >
           <span className="theme-icon theme-icon-sun" aria-hidden="true">
@@ -229,6 +230,9 @@ export function ArticleReader({
             )}
           </span>
         </button>
+        <span id={themeStatusId} className="sr-only">
+          現在は{theme === "dark" ? "ダーク" : "ライト"}モード
+        </span>
       </header>
 
       <div ref={contentRef} className="reader-scroll" tabIndex={0} aria-label="記事本文">
@@ -319,7 +323,7 @@ export function ArticleReader({
                       </span>
                     </a>
                   ) : (
-                    <Link href={item.href}>{item.title}</Link>
+                    <Link href={item.href} prefetch={false}>{item.title}</Link>
                   )}
                 </li>
               ))}

--- a/src/components/client/ArticleExperience/DesktopArticleExperience.tsx
+++ b/src/components/client/ArticleExperience/DesktopArticleExperience.tsx
@@ -8,6 +8,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react"
@@ -90,6 +91,7 @@ export default function DesktopArticleExperience({
   const [webglFailed, setWebglFailed] = useState(false)
   const [preparingWebGL, setPreparingWebGL] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const orientationStatusId = useId()
   const timers = useRef<number[]>([])
   const deviceShellRef = useRef<HTMLDivElement>(null)
   const tiltFrame = useRef<number | null>(null)
@@ -373,7 +375,7 @@ export default function DesktopArticleExperience({
             disabled={rotating || preparingWebGL || drawerOpen}
             aria-busy={rotating || preparingWebGL}
             aria-label={`${nextLabel}表示へ切り替える`}
-            aria-pressed={orientation === "landscape"}
+            aria-describedby={orientationStatusId}
           >
             <span className={`orientation-ring orientation-target-${nextOrientation}`} aria-hidden="true">
               <svg className="orientation-progress" viewBox="0 0 32 32" focusable="false">
@@ -383,12 +385,12 @@ export default function DesktopArticleExperience({
             </span>
             <span className="orientation-label" aria-hidden="true">{nextLabel}</span>
           </button>
-          <span className="orientation-status sr-only" aria-live="polite">
+          <span id={orientationStatusId} className="orientation-status sr-only" aria-live="polite">
             {preparingWebGL
               ? "端末表示を準備中"
               : rotating
-                ? `${nextLabel}表示へ切り替え中`
-                : `${orientation === "portrait" ? "縦" : "横"}表示`}
+                ? `${orientation === "portrait" ? "縦" : "横"}表示へ切り替え中`
+                : `現在は${orientation === "portrait" ? "縦" : "横"}表示`}
           </span>
         </div>
 

--- a/src/components/client/ArticleExperience/ScrollableIndex.tsx
+++ b/src/components/client/ArticleExperience/ScrollableIndex.tsx
@@ -208,6 +208,6 @@ function IndexLink({ item }: { item: ReaderIndexItem }) {
       </span>
     </a>
   ) : (
-    <Link href={item.href} aria-current={item.current ? "page" : undefined}>{item.title}</Link>
+    <Link href={item.href} prefetch={false} aria-current={item.current ? "page" : undefined}>{item.title}</Link>
   )
 }

--- a/src/lib/analytics/popular-writings.server.ts
+++ b/src/lib/analytics/popular-writings.server.ts
@@ -1,3 +1,5 @@
+import "server-only"
+
 import { createSign } from "node:crypto"
 
 import { unstable_cache } from "next/cache"

--- a/src/lib/content.test.ts
+++ b/src/lib/content.test.ts
@@ -7,6 +7,7 @@ import {
   getWritingArchives,
   getWritingBySlug,
   validateCoverImage,
+  validateExternalUrl,
   validateFrontmatterKeys,
   validateOptionalBoolean,
   validateWritingDate,
@@ -26,6 +27,13 @@ test("content identifierはURL・日付・画像rootの境界を越えない", (
   assert.equal(validateCoverImage("bun.jpg"), "bun.jpg")
   assert.throws(() => validateCoverImage("../background.jpg"), /relative path/)
   assert.throws(() => validateCoverImage("missing.png"), /existing file/)
+})
+
+test("外部記事URLはcredentialを含まないHTTPSだけを受け入れる", () => {
+  assert.equal(validateExternalUrl("https://example.com/post"), "https://example.com/post")
+  assert.throws(() => validateExternalUrl("http://example.com/post"), /absolute HTTPS URL/)
+  assert.throws(() => validateExternalUrl("https://user:pass@example.com/post"), /without credentials/)
+  assert.throws(() => validateExternalUrl("javascript:alert(1)"), /absolute HTTPS URL/)
 })
 
 test("frontmatterの未知フィールドと曖昧なbooleanを公開扱いにしない", () => {

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -174,18 +174,19 @@ const optionalDate = (data: Record<string, unknown>, key: string, filePath: stri
   return value ? validateWritingDate(value, key, filePath) : undefined
 }
 
-const requiredHttpUrl = (data: Record<string, unknown>, key: string, filePath: string) => {
-  const value = requiredString(data, key, filePath)
-
+export const validateExternalUrl = (value: string, key = "externalUrl", filePath = "content") => {
   try {
     const url = new URL(value)
-    if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error("Unsupported protocol")
+    if (url.protocol !== "https:") throw new Error("Unsupported protocol")
     if (url.username || url.password) throw new Error("Credentials are not allowed")
     return url.toString()
   } catch {
-    throw new Error(`${key} must be an absolute HTTP(S) URL: ${filePath}`)
+    throw new Error(`${key} must be an absolute HTTPS URL without credentials: ${filePath}`)
   }
 }
+
+const requiredHttpsUrl = (data: Record<string, unknown>, key: string, filePath: string) =>
+  validateExternalUrl(requiredString(data, key, filePath), key, filePath)
 
 const stringArray = (data: Record<string, unknown>, key: string, filePath: string) => {
   const value = data[key]
@@ -273,7 +274,7 @@ const getExternalWritings = (): Writing[] => {
         updatedAt: optionalDate(data, "updatedAt", filePath),
         importedAt: requiredDate(data, "importedAt", filePath),
         tags: stringArray(data, "tags", filePath),
-        externalUrl: requiredHttpUrl(data, "externalUrl", filePath),
+        externalUrl: requiredHttpsUrl(data, "externalUrl", filePath),
         platform: requiredString(data, "platform", filePath),
         featured: validateOptionalBoolean(data.featured, "featured", filePath),
         draft: validateOptionalBoolean(data.draft, "draft", filePath),


### PR DESCRIPTION
## Summary
- stop automatic RSC prefetch storms from repeated article, tag, filter, and reader-index links while retaining primary navigation prefetch
- make external content HTTPS-only, mark GA4 aggregation as server-only, and clarify orientation/theme state semantics for assistive technology
- pin CI to `.nvmrc`, audit the full dependency graph and signatures, add job/network timeouts, and update the current specification

## Review and verification
- self-review plus adversarial accessibility, network, and URL-boundary review; fixed a reversed orientation transition announcement found in the review loop
- `npm run ci`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `npm audit signatures` (451 signatures, 76 attestations)
- workflow YAML parse
- Playwright against dedicated production server: 22/22 passed
- `git diff --check`

## Stack
- Base: #863 (`feature/blog-reboot-critical-fixes`)
- Merge after #863. The hardening PR will target this branch next.