### PR TITLE
ci: update CodeQL to Node 24 runtime

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,15 +28,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: javascript-typescript
           queries: security-extended
 
       - name: Build
-        uses: github/codeql-action/autobuild@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3
+        uses: github/codeql-action/autobuild@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
 
       - name: Analyze
-        uses: github/codeql-action/analyze@e60ea984bd3baa95954f2856bcf24f9eaba46637 # v3
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: /language:javascript-typescript


### PR DESCRIPTION
## Summary

- update all CodeQL Action entries from v3 to official v4.37.5
- keep actions pinned to the verified dereferenced commit SHA
- remove the Node.js 20 runtime and December 2026 v3 deprecation warnings observed on the final main scan

## Verification

- official action metadata declares `node24` for init, autobuild, and analyze
- workflow YAML parses successfully
- `git diff --check`
- CodeQL, quality, E2E, and Vercel checks must pass before merge
