### PR TITLE
fix: reset reader orientation from home logo

### DIFF
--- a/e2e/playwright/site.spec.ts
+++ b/e2e/playwright/site.spec.ts
@@ -794,6 +794,22 @@ test("reduced motionでは短いcrossfadeで切り替える", async ({ page }) =
   await expect(experience).not.toHaveClass(/is-rotating/, { timeout: 500 })
 })
 
+test("左上ロゴは横向き端末をデフォルトの縦表示へ戻す", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.setViewportSize({ width: 1440, height: 950 })
+  await page.goto("/")
+  const experience = page.locator(".desktop-experience")
+
+  await page.getByRole("button", { name: "横表示へ切り替える" }).click()
+  await expect(experience).toHaveAttribute("data-orientation", "landscape")
+  await expect(experience).not.toHaveClass(/is-rotating/, { timeout: 500 })
+
+  await page.getByRole("link", { name: "sena-v.com ホーム" }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await expect(experience).toHaveAttribute("data-orientation", "portrait")
+  await expect(experience).not.toHaveClass(/is-rotating/, { timeout: 500 })
+})
+
 test("WebGL初期化不能でもCSS shellと記事DOMを表示する", async ({ page }) => {
   await page.addInitScript(() => {
     HTMLCanvasElement.prototype.getContext = () => null

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link"
 
+import { HomeLogoLink } from "@/components/client/HomeLogoLink"
+
 export function SiteHeader() {
   return (
     <header className="site-header">
       <div className="shell header-inner">
-        <Link className="wordmark" href="/" aria-label="sena-v.com ホーム">
-          sena-v<span aria-hidden="true">.</span>com
-        </Link>
+        <HomeLogoLink />
         <nav aria-label="メインナビゲーション">
           <ul className="nav-list">
             <li>

--- a/src/components/client/ArticleExperience/DesktopArticleExperience.tsx
+++ b/src/components/client/ArticleExperience/DesktopArticleExperience.tsx
@@ -18,6 +18,7 @@ import type {
   ReaderOrientation,
   ReaderTheme,
 } from "@/components/article-experience/types"
+import { HOME_LOGO_ACTIVATE_EVENT } from "@/components/client/HomeLogoLink"
 import { ArticleReader } from "./ArticleReader"
 import { ScrollableIndex } from "./ScrollableIndex"
 
@@ -100,7 +101,14 @@ export default function DesktopArticleExperience({
   const tiltTarget = useRef({ x: 0, y: 0, highlightX: 50, highlightY: 14 })
   const pendingOrientation = useRef<ReaderOrientation | null>(null)
   const transitionCleanup = useRef<(() => void) | null>(null)
+  const homeLogoActivateHandler = useRef<() => void>(() => undefined)
   const usesWebGL = webglSupported && !webglFailed
+
+  useEffect(() => {
+    const handleHomeLogoActivate = () => homeLogoActivateHandler.current()
+    window.addEventListener(HOME_LOGO_ACTIVATE_EVENT, handleHomeLogoActivate)
+    return () => window.removeEventListener(HOME_LOGO_ACTIVATE_EVENT, handleHomeLogoActivate)
+  }, [])
 
   useEffect(() => () => {
     timers.current.forEach(window.clearTimeout)
@@ -294,6 +302,18 @@ export default function DesktopArticleExperience({
     }
     startOrientationChange(next)
   }
+
+  function resetToPortrait() {
+    pendingOrientation.current = null
+    if (preparingWebGL) setPreparingWebGL(false)
+    if (orientation === "portrait") return
+
+    releaseDeviceTransform()
+    resetDeviceTilt()
+    startOrientationChange("portrait", reducedMotion || !usesWebGL || !webglReady)
+  }
+
+  homeLogoActivateHandler.current = resetToPortrait
 
   const nextOrientation = orientation === "portrait" ? "landscape" : "portrait"
   const nextLabel = nextOrientation === "landscape" ? "横" : "縦"

--- a/src/components/client/HomeLogoLink.tsx
+++ b/src/components/client/HomeLogoLink.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import Link from "next/link"
+import type { MouseEvent as ReactMouseEvent } from "react"
+
+export const HOME_LOGO_ACTIVATE_EVENT = "sena-v-home-logo-activate"
+
+export function HomeLogoLink() {
+  function handleClick(event: ReactMouseEvent<HTMLAnchorElement>) {
+    if (
+      event.defaultPrevented
+      || event.button !== 0
+      || event.metaKey
+      || event.ctrlKey
+      || event.shiftKey
+      || event.altKey
+    ) return
+
+    window.dispatchEvent(new Event(HOME_LOGO_ACTIVATE_EVENT))
+  }
+
+  return (
+    <Link className="wordmark" href="/" aria-label="sena-v.com ホーム" onClick={handleClick}>
+      sena-v<span aria-hidden="true">.</span>com
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary

- ページ左上のホームロゴをクリックしたとき、横向きのdesktop readerを既定の縦表示へ戻す
- 新規タブや修飾キー付きクリックでは現在の画面状態を変更しない
- 同一URLへのNext.jsクライアント遷移で向きが残るケースのE2E回帰テストを追加

## Cause

トップページ上で `/` から同じ `/` へ遷移してもreaderコンポーネントが再マウントされず、横向きのローカルstateが維持されていました。

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit` (18 passed)
- `npm run build`
- Playwright: desktop reader主要テスト + 左上ロゴ復帰テスト (2 passed)
- `http://127.0.0.1:3000/` のproduction buildで横表示 → 左上ロゴ → 縦表示を手動確認