### PR TITLE
既存デザインを保った目的のあるモーションを追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,6 +12,9 @@
   --ink: #17171a;
   --focus: #ff789a;
   --shell: min(1440px, calc(100% - 48px));
+  --motion-fast: 140ms;
+  --motion-medium: 240ms;
+  --motion-ease-out: cubic-bezier(0.22, 0.72, 0.08, 1);
   --font-sans: "Avenir Next", "Helvetica Neue", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", system-ui, sans-serif;
   --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   color-scheme: dark;
@@ -134,6 +137,34 @@ img {
   color: var(--accent-active);
 }
 
+.site-header .wordmark {
+  display: inline-flex;
+  align-items: baseline;
+  transform-origin: left center;
+  transition: transform var(--motion-fast) var(--motion-ease-out);
+}
+
+.site-header .wordmark span {
+  display: inline-block;
+  transform-origin: center;
+  transition:
+    color var(--motion-fast) ease,
+    text-shadow var(--motion-fast) ease,
+    transform var(--motion-fast) var(--motion-ease-out);
+}
+
+.site-header .wordmark:hover,
+.site-header .wordmark:focus-visible {
+  transform: translateY(-1px);
+}
+
+.site-header .wordmark:hover span,
+.site-header .wordmark:focus-visible span {
+  color: var(--accent-soft);
+  text-shadow: 0 0 7px rgb(255 79 127 / 0.4);
+  transform: translateY(-1px) scale(1.18);
+}
+
 .nav-list {
   display: flex;
   gap: clamp(18px, 3vw, 34px);
@@ -143,16 +174,38 @@ img {
 }
 
 .nav-list a {
+  position: relative;
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.72rem;
   letter-spacing: 0.06em;
   text-decoration: none;
   white-space: nowrap;
+  transition: color var(--motion-fast) ease;
 }
 
-.nav-list a:hover {
+.nav-list a::after {
+  position: absolute;
+  right: 0;
+  bottom: -7px;
+  left: 0;
+  height: 1px;
+  background: var(--accent-active);
+  content: "";
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform var(--motion-fast) var(--motion-ease-out);
+}
+
+.nav-list a:hover,
+.nav-list a:focus-visible {
   color: var(--text);
+}
+
+.nav-list a:hover::after,
+.nav-list a:focus-visible::after {
+  transform: scaleX(1);
+  transform-origin: left;
 }
 
 /* Desktop reading stage */
@@ -1172,6 +1225,15 @@ html[data-reader-theme-preference="light"] .bootstrap-reader-copy p {
   height: 30px;
   overflow: visible;
   filter: drop-shadow(0 0 5px rgb(255 47 104 / 0.16));
+  transform-origin: center;
+  transition:
+    filter var(--motion-fast) ease,
+    transform var(--motion-fast) var(--motion-ease-out);
+}
+
+.rabbit-thumb-hit.is-interacting .rabbit-thumb {
+  filter: drop-shadow(0 0 5px rgb(255 47 104 / 0.3));
+  transform: scale(1.05);
 }
 
 .rabbit-ring {
@@ -1283,6 +1345,19 @@ html[data-reader-theme-preference="light"] .article-reader,
   border-bottom: 1px solid var(--reader-line);
   backdrop-filter: blur(14px);
   cursor: pointer;
+}
+
+.reader-progress {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 1px;
+  background: var(--reader-link);
+  box-shadow: 0 0 3px color-mix(in srgb, var(--reader-link) 30%, transparent);
+  pointer-events: none;
+  transform: scaleX(0);
+  transform-origin: left;
 }
 
 .article-reader-landscape .reader-header {
@@ -2139,11 +2214,17 @@ html[data-reader-theme-preference="light"] .article-reader,
 }
 
 .timeline-title {
+  display: inline-block;
   text-decoration: none;
+  transition:
+    color var(--motion-fast) ease,
+    transform var(--motion-fast) var(--motion-ease-out);
 }
 
-.timeline-title:hover {
+.timeline-title:hover,
+.timeline-title:focus-visible {
   color: var(--accent-soft);
+  transform: translateX(3px);
 }
 
 .writing-timeline-entry > p {
@@ -2229,6 +2310,23 @@ html[data-reader-theme-preference="light"] .article-reader,
   margin: 0 0 0.35em;
   font-size: 0.9rem;
   line-height: 1.8;
+}
+
+.writings-hero,
+.about-hero {
+  animation: editorial-enter 200ms var(--motion-ease-out) both;
+}
+
+@keyframes editorial-enter {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .writings-section,
@@ -2336,6 +2434,8 @@ html[data-reader-theme-preference="light"] .article-reader,
   inset: 50% auto auto 50%;
   width: min(680px, calc(100vw - 32px));
   max-height: min(72dvh, 560px);
+  flex-direction: column;
+  overflow: hidden;
   margin: 0;
   padding: 0;
   color: var(--text);
@@ -2343,16 +2443,49 @@ html[data-reader-theme-preference="light"] .article-reader,
   border: 1px solid #3a3b44;
   border-radius: 18px;
   box-shadow: 0 28px 100px rgb(0 0 0 / 0.72), 0 0 40px rgb(255 47 104 / 0.08);
-  transform: translate(-50%, -50%);
+  opacity: 0;
+  transform: translate(-50%, calc(-50% + 6px)) scale(0.985);
+  transition:
+    opacity var(--motion-medium) ease,
+    transform var(--motion-medium) var(--motion-ease-out),
+    display var(--motion-medium) allow-discrete,
+    overlay var(--motion-medium) allow-discrete;
+}
+
+.tag-filter-popover:popover-open {
+  display: flex;
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
 }
 
 .tag-filter-popover::backdrop {
   background: rgb(3 4 6 / 0.72);
   backdrop-filter: blur(4px);
+  opacity: 0;
+  transition:
+    opacity var(--motion-fast) ease,
+    display var(--motion-medium) allow-discrete,
+    overlay var(--motion-medium) allow-discrete;
+}
+
+.tag-filter-popover:popover-open::backdrop {
+  opacity: 1;
+}
+
+@starting-style {
+  .tag-filter-popover:popover-open {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 6px)) scale(0.985);
+  }
+
+  .tag-filter-popover:popover-open::backdrop {
+    opacity: 0;
+  }
 }
 
 .tag-filter-popover-head {
   min-height: 70px;
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -2414,9 +2547,18 @@ html[data-reader-theme-preference="light"] .article-reader,
   border-color: var(--accent-active);
 }
 
+.tag-filter-form {
+  min-height: 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .tag-filter-popover .tags-cloud {
-  max-height: calc(min(72dvh, 560px) - 138px);
+  min-height: 0;
   display: grid;
+  flex: 1 1 auto;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 2px 18px;
   margin: 0;
@@ -2439,6 +2581,9 @@ html[data-reader-theme-preference="light"] .article-reader,
   font-family: var(--font-mono);
   font-size: 0.72rem;
   cursor: pointer;
+  transition:
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease;
 }
 
 .tag-filter-popover .tags-cloud label:hover {
@@ -2468,19 +2613,28 @@ html[data-reader-theme-preference="light"] .article-reader,
 .tag-check {
   color: transparent;
   font-weight: 700;
+  opacity: 0;
+  transform: scale(0.72);
+  transition:
+    color var(--motion-fast) ease,
+    opacity var(--motion-fast) ease,
+    transform var(--motion-fast) var(--motion-ease-out);
 }
 
 .tag-filter-checkbox:checked ~ .tag-check {
   color: var(--accent-active);
+  opacity: 1;
+  transform: scale(1);
 }
 
 .tag-filter-footer {
   min-height: 68px;
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  padding: 10px 16px 10px 20px;
+  padding: 12px 20px;
   border-top: 1px solid var(--line);
 }
 
@@ -2490,8 +2644,11 @@ html[data-reader-theme-preference="light"] .article-reader,
 }
 
 .tag-filter-footer button {
-  min-height: 42px;
-  padding-inline: 18px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
   color: #fff;
   background: var(--accent-active);
   border: 0;
@@ -2571,7 +2728,14 @@ html[data-reader-theme-preference="light"] .article-reader,
   grid-template-columns: 150px minmax(0, 1fr);
   column-gap: clamp(24px, 4vw, 56px);
   padding: 24px 0 26px;
+  background-color: transparent;
   border-bottom: 1px solid var(--line);
+  transition: background-color var(--motion-fast) ease;
+}
+
+.writings-page .writing-timeline-entry:has(.timeline-title:hover),
+.writings-page .writing-timeline-entry:has(.timeline-title:focus-visible) {
+  background-color: rgb(255 47 104 / 0.035);
 }
 
 .writings-page .writing-timeline-entry::before {
@@ -3318,9 +3482,48 @@ html[data-reader-theme-preference="light"] .article-reader,
   *::before,
   *::after {
     scroll-behavior: auto !important;
+    animation-delay: 0.01ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    transition-delay: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .writings-hero,
+  .about-hero {
+    animation: none !important;
+  }
+
+  .nav-list a::after {
+    opacity: 0;
+    transform: none !important;
+  }
+
+  .nav-list a:hover::after,
+  .nav-list a:focus-visible::after {
+    opacity: 1;
+  }
+
+  .timeline-title:hover,
+  .timeline-title:focus-visible {
+    transform: none !important;
+  }
+
+  .site-header .wordmark:hover,
+  .site-header .wordmark:focus-visible,
+  .site-header .wordmark:hover span,
+  .site-header .wordmark:focus-visible span {
+    transform: none !important;
+  }
+
+  .rabbit-thumb-hit.is-interacting .rabbit-thumb,
+  .tag-check {
+    transform: none !important;
+  }
+
+  .tag-filter-popover,
+  .tag-filter-popover:popover-open {
+    transform: translate(-50%, -50%) scale(1) !important;
   }
 
   .device-shell,

--- a/e2e/playwright/site.spec.ts
+++ b/e2e/playwright/site.spec.ts
@@ -524,6 +524,27 @@ test("索引はnative scrollとrabbit thumbで操作できる", async ({ page })
   expect(parseFloat(rabbitPresentation.glyphWidth)).toBeGreaterThanOrEqual(1.4)
   expect(await archive.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
   expect(await archive.evaluate((element) => getComputedStyle(element).maskImage)).not.toBe("none")
+  await expect(thumb).toHaveAttribute("data-interacting", "false")
+  await thumb.focus()
+  await thumb.press("ArrowDown")
+  await expect(thumb).toHaveAttribute("data-interacting", "true")
+  await expect.poll(() => archive.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
+  await expect(thumb).toHaveAttribute("data-interacting", "false", { timeout: 1_000 })
+
+  await archive.evaluate((element) => { element.scrollTop = 0 })
+  await expect.poll(() => archive.evaluate((element) => element.scrollTop)).toBe(0)
+  const thumbBox = await thumb.boundingBox()
+  expect(thumbBox).not.toBeNull()
+  await page.mouse.move(thumbBox!.x + thumbBox!.width / 2, thumbBox!.y + thumbBox!.height / 2)
+  await page.mouse.down()
+  await expect(thumb).toHaveAttribute("data-interacting", "true")
+  await expect.poll(() => thumb.locator(".rabbit-thumb").evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe("none")
+  await page.mouse.move(thumbBox!.x + thumbBox!.width / 2, thumbBox!.y + thumbBox!.height / 2 + 80, { steps: 4 })
+  await expect.poll(async () => Number(await thumb.getAttribute("aria-valuenow"))).toBeGreaterThan(0)
+  await page.mouse.up()
+  await expect(thumb).toHaveAttribute("data-interacting", "false")
+
   await archive.focus()
   await archive.press("End")
   await expect.poll(() => archive.evaluate((element) => element.scrollTop)).toBeGreaterThan(0)
@@ -536,6 +557,42 @@ test("索引はnative scrollとrabbit thumbで操作できる", async ({ page })
   await expect(archiveMonth).toHaveAttribute("aria-expanded", "true")
   await expect(page.locator(".archive-item").nth(1).locator(".archive-articles a").first()).toBeVisible()
   expect(page.url()).toBe(beforeExpandUrl)
+})
+
+test("読了位置はdesktop readerとmobile pageのスクロールに追従する", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 950 })
+  await page.goto("/articles/package-manager-node")
+
+  const desktopProgress = page.getByRole("progressbar", { name: "記事の読了位置" })
+  await expect(desktopProgress).toHaveAttribute("aria-valuemin", "0")
+  await expect(desktopProgress).toHaveAttribute("aria-valuemax", "100")
+  await expect(desktopProgress).toHaveAttribute("aria-valuenow", "0")
+  await page.locator(".reader-scroll").evaluate((element) => {
+    element.scrollTop = (element.scrollHeight - element.clientHeight) / 2
+  })
+  await expect.poll(async () => Number(await desktopProgress.getAttribute("aria-valuenow")))
+    .toBeGreaterThan(40)
+  expect(Number(await desktopProgress.getAttribute("aria-valuenow"))).toBeLessThan(60)
+  await page.locator(".reader-scroll").evaluate((element) => {
+    element.scrollTop = element.scrollHeight
+  })
+  await expect.poll(async () => Number(await desktopProgress.getAttribute("aria-valuenow")))
+    .toBeGreaterThanOrEqual(99)
+  await expect.poll(() => desktopProgress.evaluate((element) => (
+    new DOMMatrix(getComputedStyle(element).transform).a
+  ))).toBeGreaterThanOrEqual(0.99)
+
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto("/articles/package-manager-node")
+  const mobileProgress = page.getByRole("progressbar", { name: "記事の読了位置" })
+  await expect(mobileProgress).toHaveAttribute("aria-valuenow", "0")
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight / 2))
+  await expect.poll(async () => Number(await mobileProgress.getAttribute("aria-valuenow")))
+    .toBeGreaterThan(5)
+  expect(Number(await mobileProgress.getAttribute("aria-valuenow"))).toBeLessThan(95)
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+  await expect.poll(async () => Number(await mobileProgress.getAttribute("aria-valuenow")))
+    .toBeGreaterThanOrEqual(99)
 })
 
 test("関連記事・人気記事・archiveの遷移中にSPレイアウトやthemeへ戻らない", async ({ page }) => {
@@ -792,6 +849,30 @@ test("reduced motionでは短いcrossfadeで切り替える", async ({ page }) =
   await page.getByRole("button", { name: "横表示へ切り替える" }).click()
   await expect(experience).toHaveAttribute("data-orientation", "landscape")
   await expect(experience).not.toHaveClass(/is-rotating/, { timeout: 500 })
+
+  await page.goto("/writings")
+  const hero = page.locator(".writings-hero")
+  await expect(hero).toHaveCSS("animation-name", "none")
+  await expect(hero).toHaveCSS("opacity", "1")
+  const wordmark = page.getByRole("link", { name: "sena-v.com ホーム" })
+  await wordmark.focus()
+  await expect(wordmark).toHaveCSS("transform", "none")
+  await expect(wordmark.locator("span")).toHaveCSS("transform", "none")
+  const timelineTitle = page.locator(".timeline-title").first()
+  await timelineTitle.focus()
+  const transitionDurationMs = async (element: typeof timelineTitle) => element.evaluate((target) => {
+    const value = getComputedStyle(target).transitionDuration.split(",")[0].trim()
+    return Number.parseFloat(value) * (value.endsWith("ms") ? 1 : 1_000)
+  })
+  expect(await transitionDurationMs(timelineTitle)).toBeLessThanOrEqual(1)
+  await expect(timelineTitle).toHaveCSS("transform", "none")
+  const homeLink = page.locator(".site-header .nav-list a").filter({ hasText: "ホーム" })
+  await homeLink.focus()
+  expect(await homeLink.evaluate((element) => getComputedStyle(element, "::after").transform)).toBe("none")
+  await page.getByRole("button", { name: /タグで絞り込む/ }).click()
+  const tagDialog = page.getByRole("dialog", { name: "タグで絞り込む" })
+  await expect(tagDialog).toBeVisible()
+  expect(await transitionDurationMs(tagDialog)).toBeLessThanOrEqual(1)
 })
 
 test("WebGL初期化不能でもCSS shellと記事DOMを表示する", async ({ page }) => {
@@ -956,6 +1037,40 @@ test("記事一覧とAboutは1280pxの初見で主要内容まで見える密度
   await page.getByRole("button", { name: /タグで絞り込む/ }).click()
   const tagDialog = page.getByRole("dialog", { name: "タグで絞り込む" })
   await expect(tagDialog).toBeVisible()
+  const expandedTagLayout = await tagDialog.evaluate((dialog) => {
+    const cloud = dialog.querySelector(".tags-cloud")
+    const footer = dialog.querySelector(".tag-filter-footer")
+    const applyButton = footer?.querySelector("button")
+    if (!cloud || !footer || !applyButton) return null
+
+    const originalItems = [...cloud.children]
+    const scrollHeightBefore = cloud.scrollHeight
+    for (let repeat = 0; repeat < 2; repeat += 1) {
+      originalItems.forEach((item) => cloud.append(item.cloneNode(true)))
+    }
+    cloud.scrollTop = cloud.scrollHeight
+
+    const dialogBox = dialog.getBoundingClientRect()
+    const footerBox = footer.getBoundingClientRect()
+    const buttonBox = applyButton.getBoundingClientRect()
+    return {
+      tagCountBefore: originalItems.length,
+      tagCountAfter: cloud.children.length,
+      scrollHeightBefore,
+      scrollHeightAfter: cloud.scrollHeight,
+      scrollTop: cloud.scrollTop,
+      footerBottomGap: dialogBox.bottom - footerBox.bottom,
+      buttonBottomGap: dialogBox.bottom - buttonBox.bottom,
+      buttonRightGap: dialogBox.right - buttonBox.right,
+    }
+  })
+  if (!expandedTagLayout) throw new Error("タグpopoverのレイアウト要素を取得できません")
+  expect(expandedTagLayout.tagCountAfter).toBe(expandedTagLayout.tagCountBefore * 3)
+  expect(expandedTagLayout.scrollHeightAfter).toBeGreaterThan(expandedTagLayout.scrollHeightBefore)
+  expect(expandedTagLayout.scrollTop).toBeGreaterThan(0)
+  expect(expandedTagLayout.footerBottomGap).toBeGreaterThanOrEqual(0)
+  expect(expandedTagLayout.buttonBottomGap).toBeGreaterThanOrEqual(10)
+  expect(expandedTagLayout.buttonRightGap).toBeGreaterThanOrEqual(10)
   expect(await page.locator(".writing-timeline-entry").first().evaluate((element) => element.getBoundingClientRect().top))
     .toBeCloseTo(firstEntryTopBeforeTags, 0)
   await page.getByRole("button", { name: "タグ選択を閉じる" }).click()
@@ -1003,6 +1118,64 @@ test("記事一覧とAboutは1280pxの初見で主要内容まで見える密度
   expect(mobileAbout.firstChapterRight).toBeLessThan(mobileAbout.viewportWidth)
   expect(mobileAbout.linksRight).toBeLessThan(mobileAbout.viewportWidth)
   expect(mobileAbout.navigationRight).toBeLessThanOrEqual(mobileAbout.viewportWidth)
+})
+
+test("記事一覧の動きはhero・wordmark・navigation・記事行・タグ操作に限定する", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await page.goto("/writings")
+
+  const hero = page.locator(".writings-hero")
+  await expect(hero).toHaveCSS("animation-name", "editorial-enter")
+  expect(await hero.evaluate((element) => Number.parseFloat(getComputedStyle(element).animationDuration)))
+    .toBeGreaterThan(0)
+
+  const homeLink = page.locator(".site-header .nav-list a").filter({ hasText: "ホーム" })
+  const initialUnderline = await homeLink.evaluate((element) => getComputedStyle(element, "::after").transform)
+  await homeLink.focus()
+  await expect.poll(() => homeLink.evaluate((element) => getComputedStyle(element, "::after").transform))
+    .not.toBe(initialUnderline)
+
+  const wordmark = page.getByRole("link", { name: "sena-v.com ホーム" })
+  const wordmarkDot = wordmark.locator("span")
+  const initialWordmarkTransform = await wordmark.evaluate((element) => getComputedStyle(element).transform)
+  const initialDotTransform = await wordmarkDot.evaluate((element) => getComputedStyle(element).transform)
+  await wordmark.hover()
+  await expect.poll(() => wordmark.evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe(initialWordmarkTransform)
+  await expect.poll(() => wordmarkDot.evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe(initialDotTransform)
+  await page.mouse.move(0, 0)
+  await wordmark.focus()
+  await expect.poll(() => wordmark.evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe(initialWordmarkTransform)
+
+  const firstTitle = page.locator(".timeline-title").first()
+  const firstEntry = firstTitle.locator("xpath=ancestor::*[contains(@class, 'writing-timeline-entry')]")
+  const initialTitleTransform = await firstTitle.evaluate((element) => getComputedStyle(element).transform)
+  await firstTitle.hover()
+  await expect.poll(() => firstTitle.evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe(initialTitleTransform)
+  await expect.poll(() => firstEntry.evaluate((element) => getComputedStyle(element).backgroundColor))
+    .not.toBe("rgba(0, 0, 0, 0)")
+  await page.mouse.move(0, 0)
+  await firstTitle.focus()
+  await expect.poll(() => firstTitle.evaluate((element) => getComputedStyle(element).transform))
+    .not.toBe(initialTitleTransform)
+
+  await page.getByRole("button", { name: /タグで絞り込む/ }).click()
+  const tagDialog = page.getByRole("dialog", { name: "タグで絞り込む" })
+  await expect(tagDialog).toBeVisible()
+  await expect.poll(() => tagDialog.evaluate((element) => getComputedStyle(element).opacity)).toBe("1")
+  expect(await tagDialog.evaluate((element) => Number.parseFloat(getComputedStyle(element).transitionDuration)))
+    .toBeGreaterThan(0)
+  const tagCheckbox = tagDialog.getByRole("checkbox", { name: /技術/ })
+  await tagDialog.getByText("技術", { exact: true }).click()
+  await expect(tagCheckbox).toBeChecked()
+  await expect.poll(() => tagCheckbox.evaluate((element) => (
+    getComputedStyle(element.parentElement!.querySelector(".tag-check")!).opacity
+  ))).toBe("1")
+  await page.getByRole("button", { name: "タグ選択を閉じる" }).click()
+  await expect(tagDialog).toBeHidden()
 })
 
 test("ローカル記事にmetadata・構造化データ・目次がある", async ({ page }) => {

--- a/src/components/client/ArticleExperience/ArticleReader.tsx
+++ b/src/components/client/ArticleExperience/ArticleReader.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { useEffect, useId, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react"
+import { useCallback, useEffect, useId, useMemo, useRef, type MouseEvent as ReactMouseEvent } from "react"
 
 import { MarkdownArticle } from "@/components/MarkdownArticle"
 import type {
@@ -39,17 +39,92 @@ export function ArticleReader({
   reducedMotion = false,
   mobile = false,
 }: ArticleReaderProps) {
+  const readerRef = useRef<HTMLElement>(null)
   const dialogRef = useRef<HTMLDialogElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
+  const progressRef = useRef<HTMLSpanElement>(null)
+  const progressFrameRef = useRef<number | null>(null)
+  const lastProgressPercentRef = useRef(-1)
+  const mobileProgressRangeRef = useRef({ top: 0, max: 0 })
   const restoreTriggerFocusRef = useRef(true)
   const onMenuStateChangeRef = useRef(onMenuStateChange)
   const themeStatusId = useId()
   const headings = useMemo(() => extractMarkdownHeadings(writing.content), [writing.content])
 
+  const updateReadingProgress = useCallback(() => {
+    const progress = progressRef.current
+    if (!progress) return
+
+    let value = 0
+    let max = 0
+    if (mobile) {
+      const range = mobileProgressRangeRef.current
+      value = window.scrollY - range.top
+      max = range.max
+    } else {
+      const scroller = contentRef.current
+      if (!scroller) return
+      value = scroller.scrollTop
+      max = scroller.scrollHeight - scroller.clientHeight
+    }
+
+    const ratio = max > 0 ? Math.min(1, Math.max(0, value / max)) : 0
+    const percent = Math.round(ratio * 100)
+    progress.style.transform = `scaleX(${ratio.toFixed(4)})`
+    if (lastProgressPercentRef.current !== percent) {
+      lastProgressPercentRef.current = percent
+      progress.setAttribute("aria-valuenow", String(percent))
+    }
+  }, [mobile])
+
+  const queueReadingProgress = useCallback(() => {
+    if (progressFrameRef.current !== null) return
+    progressFrameRef.current = window.requestAnimationFrame(() => {
+      progressFrameRef.current = null
+      updateReadingProgress()
+    })
+  }, [updateReadingProgress])
+
   useEffect(() => {
     onMenuStateChangeRef.current = onMenuStateChange
   }, [onMenuStateChange])
+
+  useEffect(() => {
+    const reader = readerRef.current
+    const scroller = contentRef.current
+    const measureProgressRange = () => {
+      if (mobile && reader) {
+        mobileProgressRangeRef.current = {
+          top: reader.getBoundingClientRect().top + window.scrollY,
+          max: Math.max(0, reader.scrollHeight - window.innerHeight),
+        }
+      }
+      queueReadingProgress()
+    }
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measureProgressRange)
+
+    measureProgressRange()
+    window.addEventListener("resize", measureProgressRange)
+    if (mobile) {
+      window.addEventListener("scroll", queueReadingProgress, { passive: true })
+      if (reader) observer?.observe(reader)
+    } else if (scroller) {
+      scroller.addEventListener("scroll", queueReadingProgress, { passive: true })
+      observer?.observe(scroller.firstElementChild ?? scroller)
+    }
+
+    return () => {
+      window.removeEventListener("resize", measureProgressRange)
+      window.removeEventListener("scroll", queueReadingProgress)
+      scroller?.removeEventListener("scroll", queueReadingProgress)
+      observer?.disconnect()
+      if (progressFrameRef.current !== null) {
+        window.cancelAnimationFrame(progressFrameRef.current)
+        progressFrameRef.current = null
+      }
+    }
+  }, [mobile, orientation, queueReadingProgress, writing.slug])
 
   useEffect(() => {
     const dialog = dialogRef.current
@@ -166,6 +241,7 @@ export function ArticleReader({
 
   return (
     <section
+      ref={readerRef}
       className={`article-reader article-reader-${orientation}${mobile ? " article-reader-mobile" : ""}`}
       data-reader-theme={theme}
       aria-label={`${writing.title}の記事reader`}
@@ -233,6 +309,15 @@ export function ArticleReader({
         <span id={themeStatusId} className="sr-only">
           現在は{theme === "dark" ? "ダーク" : "ライト"}モード
         </span>
+        <span
+          ref={progressRef}
+          className="reader-progress"
+          role="progressbar"
+          aria-label="記事の読了位置"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={0}
+        />
       </header>
 
       <div ref={contentRef} className="reader-scroll" tabIndex={0} aria-label="記事本文">

--- a/src/components/client/ArticleExperience/ScrollableIndex.tsx
+++ b/src/components/client/ArticleExperience/ScrollableIndex.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useId, useRef, useState, type KeyboardEvent, ty
 import type { ReaderIndexItem } from "@/components/article-experience/types"
 
 const RABBIT_THUMB_SIZE = 30
+const RABBIT_KEYBOARD_FEEDBACK_DURATION = 280
 
 type ScrollableIndexProps = {
   title: string
@@ -27,7 +28,9 @@ export function ScrollableIndex({
   const scrollerRef = useRef<HTMLDivElement>(null)
   const railRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<{ pointerY: number; scrollTop: number } | null>(null)
+  const interactionTimerRef = useRef<number | null>(null)
   const [position, setPosition] = useState({ value: 0, max: 0, ratio: 0 })
+  const [isInteracting, setIsInteracting] = useState(false)
   const [expandedArchiveId, setExpandedArchiveId] = useState<string | null>(() =>
     variant === "archive"
       ? items.find((item) => item.children?.some((child) => child.current))?.id ?? null
@@ -51,6 +54,10 @@ export function ScrollableIndex({
     return () => observer.disconnect()
   }, [items, updatePosition])
 
+  useEffect(() => () => {
+    if (interactionTimerRef.current !== null) window.clearTimeout(interactionTimerRef.current)
+  }, [])
+
   function scrollByAmount(amount: number) {
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     scrollerRef.current?.scrollBy({ top: amount, behavior: reduceMotion ? "auto" : "smooth" })
@@ -69,12 +76,23 @@ export function ScrollableIndex({
     const amount = amounts[event.key]
     if (amount === undefined) return
     event.preventDefault()
+    setIsInteracting(true)
+    if (interactionTimerRef.current !== null) window.clearTimeout(interactionTimerRef.current)
+    interactionTimerRef.current = window.setTimeout(() => {
+      interactionTimerRef.current = null
+      setIsInteracting(false)
+    }, RABBIT_KEYBOARD_FEEDBACK_DURATION)
     scrollByAmount(amount)
   }
 
   function handlePointerDown(event: PointerEvent<HTMLDivElement>) {
     const scroller = scrollerRef.current
-    if (!scroller) return
+    if (!scroller || position.max <= 0) return
+    if (interactionTimerRef.current !== null) {
+      window.clearTimeout(interactionTimerRef.current)
+      interactionTimerRef.current = null
+    }
+    setIsInteracting(true)
     dragRef.current = { pointerY: event.clientY, scrollTop: scroller.scrollTop }
     event.currentTarget.setPointerCapture(event.pointerId)
   }
@@ -90,6 +108,7 @@ export function ScrollableIndex({
 
   function stopDragging(event: PointerEvent<HTMLDivElement>) {
     dragRef.current = null
+    setIsInteracting(false)
     if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId)
   }
 
@@ -160,7 +179,7 @@ export function ScrollableIndex({
         </div>
         <div ref={railRef} className="scroll-rail" aria-hidden={position.max === 0}>
           <div
-            className="rabbit-thumb-hit"
+            className={`rabbit-thumb-hit${isInteracting ? " is-interacting" : ""}`}
             role="scrollbar"
             tabIndex={position.max > 0 ? 0 : -1}
             aria-controls={regionId}
@@ -169,12 +188,14 @@ export function ScrollableIndex({
             aria-valuemin={0}
             aria-valuemax={Math.round(position.max)}
             aria-valuenow={Math.round(position.value)}
+            data-interacting={isInteracting ? "true" : "false"}
             style={{ top: `calc(${position.ratio * 100}% - ${position.ratio * RABBIT_THUMB_SIZE}px)` }}
             onKeyDown={handleThumbKeyDown}
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
             onPointerUp={stopDragging}
             onPointerCancel={stopDragging}
+            onLostPointerCapture={stopDragging}
           >
             <RabbitThumb />
           </div>


### PR DESCRIPTION
## 概要
- Readerヘッダーへスクロール追従の読了進捗を追加
- navigation、記事行、タグ選択、Rabbit scrollbarへ控えめな操作フィードバックを追加
- Writings / About heroへ一度だけのfade-upを追加
- ヘッダーwordmarkへhover / focus時の短いliftとアクセントドット反応を追加
- タグ数が増えても一覧だけがスクロールするpopoverレイアウトへ変更
- prefers-reduced-motionでは空間移動を停止

## 検証
- npm run ci
- npm run e2e:playwright（24件成功）
- desktop / mobile / reduced-motionの実画面確認